### PR TITLE
feat: add modular API template generator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+dist
+coverage
+.env
+.env.*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Server
+PORT=3333
+NODE_ENV=development
+LOG_LEVEL=info
+ENABLE_SWAGGER=true
+
+# Security
+JWT_SECRET=change-me-to-a-long-random-string
+JWT_EXPIRES_IN=15m
+REFRESH_TOKEN_TTL_MS=604800000
+
+# Database
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/template?schema=public
+
+# Rate limiting
+RATE_LIMIT_WINDOW_MS=900000
+RATE_LIMIT_MAX=100
+
+# CORS
+CORS_ORIGIN=http://localhost:3000

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+coverage
+prisma/migrations

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2020: true,
+    jest: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-console': 'warn'
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15-alpine
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: template
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/template?schema=public
+      JWT_SECRET: ci-secret-ci-secret-ci-secret-1234567890
+      JWT_EXPIRES_IN: 15m
+      REFRESH_TOKEN_TTL_MS: 604800000
+      RATE_LIMIT_WINDOW_MS: 900000
+      RATE_LIMIT_MAX: 100
+      ENABLE_SWAGGER: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Run migrations
+        run: npm run db:migrate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.DS_Store
+.env
+coverage
+dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json tsconfig.json ./
+COPY prisma ./prisma
+RUN npm install
+RUN npx prisma generate
+
+FROM deps AS build
+COPY . .
+RUN npm run build
+RUN npm prune --production
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+EXPOSE 3333
+CMD ["sh", "-c", "npm run db:migrate && npm run start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# TemplateAPI
+# create-template-api
+
+**create-template-api** est un générateur interactif de bases d'API Node.js prêtes pour la production.
+Il permet de sélectionner dynamiquement le langage (TypeScript ou JavaScript) ainsi que les modules
+fonctionnels (authentification JWT, gestion d'utilisateurs, espaces client / admin, etc.) sans
+aucune dépendance à une base de données.
+
+## ✨ Points clés
+
+- Architecture hexagonale complète : `domain`, `application`, `infrastructure`, `interface`.
+- Sécurité HTTP (Helmet, CORS, rate limiting) et logging structuré (Pino) préconfigurés.
+- Validation des entrées avec Zod et gestion centralisée des erreurs.
+- Authentification JWT avec refresh token rotatif, hashage bcrypt et rôles (admin / client).
+- Documentation OpenAPI + collection Insomnia générées automatiquement.
+- Tests prêts à l'emploi (Jest + Supertest) avec dépôts en mémoire.
+- Dockerfile, docker-compose et scripts npm pour un onboarding immédiat.
+
+## 🚀 Utilisation
+
+```bash
+# installer les dépendances du générateur
+npm install
+
+# lancer le générateur (interactif)
+npm run dev
+# ou après build
+npm run build
+node dist/cli/index.js
+```
+
+### Exécution directe
+
+```bash
+# générer une API TypeScript avec authentification et gestion utilisateurs
+node dist/cli/index.js my-api \
+  --language typescript \
+  --features auth,userCrud,clientPortal,adminPortal \
+  --package-manager npm
+```
+
+## 🧭 Options disponibles
+
+| Option | Description |
+|--------|-------------|
+| `--language` | `typescript` (par défaut) ou `javascript`. |
+| `--features` | Modules à inclure séparés par des virgules : `auth`, `userCrud`, `clientPortal`, `adminPortal`. Les dépendances sont résolues automatiquement (ex: `userCrud` active `auth`). |
+| `--package-manager` | `npm`, `pnpm` ou `yarn`. Détermine les scripts affichés dans le README généré. |
+| `--dry-run` | Simule la génération sans écrire de fichiers. |
+
+## 📦 Sortie générée
+
+Le projet créé contient :
+
+- un dossier `src/` structuré par couches hexagonales,
+- des tests (`tests/`) et utilitaires prêts à l'emploi,
+- la documentation (`docs/insomnia`, `src/interface/http/docs/openapi`),
+- des fichiers de configuration (ESLint, Prettier, Jest, Docker).
+
+La version JavaScript est générée à partir des mêmes sources TypeScript et convertie automatiquement.
+
+## 🛠 Développement
+
+| Script | Description |
+| ------ | ----------- |
+| `npm run dev` | Lance le CLI en TypeScript (ts-node). |
+| `npm run build` | Compile le CLI vers `dist/`. |
+| `npm test` | Vérifie la compilation TypeScript sans émettre de fichiers. |
+
+## 📄 Licence
+
+Ce projet est sous licence MIT.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.9'
+
+services:
+  api:
+    build: .
+    ports:
+      - '3333:3333'
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/template?schema=public}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: template
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  setupFiles: ['<rootDir>/tests/setup-env.ts'],
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1'
+  }
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "template-api",
+  "version": "1.0.0",
+  "description": "Générateur d'API hexagonale modulaire sans base de données.",
+  "main": "dist/cli/index.js",
+  "bin": {
+    "create-template-api": "dist/cli/index.js"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node src/cli/index.ts",
+    "test": "tsc -p tsconfig.json --noEmit"
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "keywords": ["cli", "api", "template", "express", "typescript"],
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "commander": "^11.1.0",
+    "ejs": "^3.1.9",
+    "fs-extra": "^11.2.0",
+    "inquirer": "^9.2.7",
+    "typescript": "^5.4.2"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.11.20",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import chalk from 'chalk';
+import { promptForMissingOptions, PromptOptions } from '../prompts/prompts';
+import { Language } from '../generators/types';
+import { getGeneratorForLanguage } from '../generators/registry';
+
+export interface CreateCommandOptions extends PromptOptions {
+  dryRun?: boolean;
+}
+
+function ensureSafeProjectDirectory(targetDir: string) {
+  if (!fs.existsSync(targetDir)) {
+    return;
+  }
+
+  const stats = fs.statSync(targetDir);
+  if (!stats.isDirectory()) {
+    throw new Error(`${targetDir} existe déjà et n'est pas un dossier.`);
+  }
+
+  const files = fs.readdirSync(targetDir);
+  if (files.length > 0) {
+    throw new Error(`Le dossier ${targetDir} n'est pas vide. Choisissez un dossier vide ou un nouveau nom.`);
+  }
+}
+
+export async function runCreateCommand(directoryArg: string | undefined, options: CreateCommandOptions) {
+  const answers = await promptForMissingOptions(options);
+
+  const targetDirectoryName = directoryArg ?? answers.projectName;
+  const targetDirectory = path.resolve(process.cwd(), targetDirectoryName);
+
+  ensureSafeProjectDirectory(targetDirectory);
+
+  const generator = getGeneratorForLanguage(answers.language as Language);
+
+  await generator.generate({
+    projectName: answers.projectName,
+    targetDirectory,
+    language: answers.language,
+    features: answers.features,
+    packageManager: answers.packageManager,
+    dryRun: options.dryRun ?? false,
+  });
+
+  const relativePath = path.relative(process.cwd(), targetDirectory) || '.';
+
+  const instructions = `\n${chalk.bold('Prochaines étapes :')}\n` +
+    `  ${chalk.cyan(`cd ${relativePath}`)}\n` +
+    `  ${chalk.cyan(`${answers.packageManager} install`)}\n` +
+    `  ${chalk.cyan(`${answers.packageManager} run dev`)}\n`;
+
+  console.log('\n' + chalk.green('✅ Template API généré avec succès !'));
+  console.log(instructions);
+}

--- a/src/cli/generators/base-generator.ts
+++ b/src/cli/generators/base-generator.ts
@@ -1,0 +1,171 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import ejs from 'ejs';
+import { FeatureDefinition, FeatureKey, Language, featureCatalogMap } from './types';
+
+export interface DependencyItem {
+  name: string;
+  version: string;
+}
+
+export interface TemplateDependencies {
+  dependencies: DependencyItem[];
+  devDependencies: DependencyItem[];
+  scripts: Record<string, string>;
+}
+
+export interface GenerateProjectOptions {
+  projectName: string;
+  targetDirectory: string;
+  language: Language;
+  features: FeatureKey[];
+  packageManager: 'npm' | 'pnpm' | 'yarn';
+  dryRun?: boolean;
+}
+
+interface PackageManagerCommands {
+  install: string;
+  run: string;
+  exec: string;
+}
+
+export interface TemplateContext {
+  projectName: string;
+  packageName: string;
+  language: Language;
+  features: FeatureKey[];
+  selectedFeatures: FeatureDefinition[];
+  featureSummaries: string[];
+  dependencies: DependencyItem[];
+  devDependencies: DependencyItem[];
+  scripts: Record<string, string>;
+  packageManager: 'npm' | 'pnpm' | 'yarn';
+  packageManagerCommands: PackageManagerCommands;
+  year: number;
+  createdAt: string;
+  [key: string]: unknown;
+}
+
+export abstract class BaseTemplateGenerator {
+  constructor(private readonly templateRoot: string) {}
+
+  async generate(options: GenerateProjectOptions) {
+    const { targetDirectory, features, projectName, language, packageManager } = options;
+
+    if (!options.dryRun) {
+      await fs.ensureDir(targetDirectory);
+    }
+
+    const selectedFeatures = features.map((featureKey) => {
+      const feature = featureCatalogMap.get(featureKey);
+      if (!feature) {
+        throw new Error(`Module inconnu: ${featureKey}`);
+      }
+      return feature;
+    });
+
+    const dependencies = this.buildDependencies(language, features);
+
+    const packageName = toPackageName(projectName);
+    const packageManagerCommands = getPackageManagerCommands(packageManager);
+
+    const context: TemplateContext = {
+      projectName,
+      packageName,
+      language,
+      features,
+      selectedFeatures,
+      featureSummaries: selectedFeatures.map((feature) => feature.summary),
+      dependencies: dependencies.dependencies,
+      devDependencies: dependencies.devDependencies,
+      scripts: dependencies.scripts,
+      packageManager,
+      packageManagerCommands,
+      year: new Date().getFullYear(),
+      createdAt: new Date().toISOString(),
+      ...this.getAdditionalContext(options, dependencies),
+    };
+
+    if (!options.dryRun) {
+      await this.copyTemplateDirectory(this.getBaseTemplateDir(), targetDirectory, context);
+
+      for (const featureKey of features) {
+        const featureDir = this.getFeatureTemplateDir(featureKey);
+        if (featureDir) {
+          await this.copyTemplateDirectory(featureDir, targetDirectory, context);
+        }
+      }
+    }
+
+    await this.afterGenerate(options, context);
+  }
+
+  protected abstract getBaseTemplateDir(): string;
+  protected abstract getFeatureTemplateDir(feature: FeatureKey): string | undefined;
+  protected abstract buildDependencies(language: Language, features: FeatureKey[]): TemplateDependencies;
+
+  protected getAdditionalContext(
+    _options: GenerateProjectOptions,
+    _dependencies: TemplateDependencies
+  ): Record<string, unknown> {
+    return {};
+  }
+
+  protected async afterGenerate(_options: GenerateProjectOptions, _context: TemplateContext): Promise<void> {}
+
+  protected async copyTemplateDirectory(templateDir: string, destinationDir: string, context: TemplateContext) {
+    const entries = await fs.readdir(templateDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const sourcePath = path.join(templateDir, entry.name);
+      const destinationBaseName = entry.name.replace(/\.ejs$/, '');
+      const destinationPath = path.join(destinationDir, destinationBaseName);
+
+      if (entry.isDirectory()) {
+        await this.copyTemplateDirectory(sourcePath, destinationPath, context);
+      } else if (entry.name.endsWith('.ejs')) {
+        const rendered = await ejs.renderFile(sourcePath, context, { async: true });
+        const transformed = this.transformRenderedFile(destinationPath, rendered);
+        if (transformed === null) {
+          continue;
+        }
+        const finalPath = transformed?.fileName
+          ? path.join(path.dirname(destinationPath), transformed.fileName)
+          : destinationPath;
+        await fs.ensureDir(path.dirname(finalPath));
+        await fs.writeFile(finalPath, transformed?.content ?? rendered, 'utf8');
+      } else {
+        await fs.ensureDir(path.dirname(destinationPath));
+        await fs.copy(sourcePath, destinationPath);
+      }
+    }
+  }
+
+  protected transformRenderedFile(
+    _filePath: string,
+    content: string
+  ): { content: string; fileName?: string } | undefined | null {
+    return { content };
+  }
+}
+
+function getPackageManagerCommands(packageManager: 'npm' | 'pnpm' | 'yarn'): PackageManagerCommands {
+  switch (packageManager) {
+    case 'npm':
+      return { install: 'npm install', run: 'npm run', exec: 'npx' };
+    case 'pnpm':
+      return { install: 'pnpm install', run: 'pnpm', exec: 'pnpm dlx' };
+    case 'yarn':
+    default:
+      return { install: 'yarn install', run: 'yarn', exec: 'yarn dlx' };
+  }
+}
+
+function toPackageName(projectName: string): string {
+  return projectName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    || 'template-api';
+}

--- a/src/cli/generators/javascript-generator.ts
+++ b/src/cli/generators/javascript-generator.ts
@@ -1,0 +1,120 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import ts from 'typescript';
+import { BaseTemplateGenerator, GenerateProjectOptions, TemplateDependencies, TemplateContext } from './base-generator';
+import { FeatureKey, Language } from './types';
+
+const templateRoot = path.resolve(__dirname, '../../..', 'templates', 'javascript');
+
+export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
+  constructor() {
+    super(templateRoot);
+  }
+
+  protected getBaseTemplateDir(): string {
+    return path.join(templateRoot, 'base');
+  }
+
+  protected getFeatureTemplateDir(feature: FeatureKey): string | undefined {
+    const featurePath = path.join(templateRoot, 'features', feature);
+    return fs.existsSync(featurePath) ? featurePath : undefined;
+  }
+
+  protected buildDependencies(_language: Language, features: FeatureKey[]): TemplateDependencies {
+    const dependencies = [
+      { name: 'cors', version: '^2.8.5' },
+      { name: 'dotenv', version: '^16.4.1' },
+      { name: 'express', version: '^4.18.2' },
+      { name: 'express-rate-limit', version: '^6.11.2' },
+      { name: 'helmet', version: '^7.0.0' },
+      { name: 'pino', version: '^8.16.1' },
+      { name: 'pino-http', version: '^9.0.1' },
+      { name: 'pino-pretty', version: '^10.3.1' },
+      { name: 'swagger-ui-express', version: '^5.0.0' },
+      { name: 'zod', version: '^3.22.4' },
+    ];
+
+    const devDependencies = [
+      { name: 'eslint', version: '^8.56.0' },
+      { name: 'eslint-config-prettier', version: '^9.1.0' },
+      { name: 'jest', version: '^29.7.0' },
+      { name: 'nodemon', version: '^3.0.3' },
+      { name: 'prettier', version: '^3.2.5' },
+      { name: 'supertest', version: '^7.1.1' },
+    ];
+
+    if (features.includes('auth')) {
+      dependencies.push({ name: 'bcryptjs', version: '^2.4.3' });
+      dependencies.push({ name: 'jsonwebtoken', version: '^9.0.2' });
+    }
+
+    const scripts: Record<string, string> = {
+      dev: 'nodemon src/server.js',
+      start: 'node src/server.js',
+      build: 'echo \"No build step required\"',
+      test: 'jest --passWithNoTests',
+      'test:watch': 'jest --watch',
+      lint: 'eslint "src/**/*.js"',
+      format: 'prettier --write "src/**/*.js"',
+    };
+
+    return {
+      dependencies,
+      devDependencies,
+      scripts,
+    };
+  }
+
+  protected getAdditionalContext(options: GenerateProjectOptions, _dependencies: TemplateDependencies) {
+    return {
+      isTypeScript: false,
+      hasAuth: options.features.includes('auth'),
+      hasUserCrud: options.features.includes('userCrud'),
+      hasClientPortal: options.features.includes('clientPortal'),
+      hasAdminPortal: options.features.includes('adminPortal'),
+    };
+  }
+
+  protected transformRenderedFile(filePath: string, content: string) {
+    if (filePath.endsWith('.d.ts')) {
+      return null;
+    }
+
+    if (filePath.endsWith('.ts')) {
+      const transpiled = ts.transpileModule(content, {
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          target: ts.ScriptTarget.ES2021,
+          esModuleInterop: true,
+        },
+      });
+
+      const fileName = path.basename(filePath).replace(/\.ts$/, '.js');
+      return { content: transpiled.outputText, fileName };
+    }
+
+    return super.transformRenderedFile(filePath, content);
+  }
+
+  protected async afterGenerate(options: GenerateProjectOptions, context: TemplateContext): Promise<void> {
+    if (options.dryRun) {
+      return;
+    }
+
+    const typescriptRoot = path.resolve(__dirname, '../../..', 'templates', 'typescript');
+    const baseSrc = path.join(typescriptRoot, 'base', 'src');
+    const baseTests = path.join(typescriptRoot, 'base', 'tests');
+    const baseDocs = path.join(typescriptRoot, 'base', 'docs');
+
+    await this.copyTemplateDirectory(baseSrc, path.join(options.targetDirectory, 'src'), context);
+    await this.copyTemplateDirectory(baseTests, path.join(options.targetDirectory, 'tests'), context);
+    await this.copyTemplateDirectory(baseDocs, path.join(options.targetDirectory, 'docs'), context);
+
+    for (const feature of options.features) {
+      const featureDir = path.join(typescriptRoot, 'features', feature);
+      if (fs.existsSync(featureDir)) {
+        await this.copyTemplateDirectory(featureDir, options.targetDirectory, context);
+      }
+    }
+  }
+}

--- a/src/cli/generators/registry.ts
+++ b/src/cli/generators/registry.ts
@@ -1,0 +1,17 @@
+import { JavaScriptTemplateGenerator } from './javascript-generator';
+import { BaseTemplateGenerator } from './base-generator';
+import { Language } from './types';
+import { TypeScriptTemplateGenerator } from './typescript-generator';
+
+const generators: Record<Language, BaseTemplateGenerator> = {
+  javascript: new JavaScriptTemplateGenerator(),
+  typescript: new TypeScriptTemplateGenerator(),
+};
+
+export function getGeneratorForLanguage(language: Language): BaseTemplateGenerator {
+  const generator = generators[language];
+  if (!generator) {
+    throw new Error(`Aucun générateur disponible pour le langage ${language}`);
+  }
+  return generator;
+}

--- a/src/cli/generators/types.ts
+++ b/src/cli/generators/types.ts
@@ -1,0 +1,75 @@
+export type Language = 'typescript' | 'javascript';
+
+export type FeatureKey =
+  | 'auth'
+  | 'userCrud'
+  | 'clientPortal'
+  | 'adminPortal';
+
+export interface FeatureDefinition {
+  key: FeatureKey;
+  name: string;
+  description: string;
+  summary: string;
+  dependencies?: FeatureKey[];
+}
+
+export const featureCatalog: FeatureDefinition[] = [
+  {
+    key: 'auth',
+    name: 'Authentification JWT',
+    description:
+      "Inscrit et authentifie des utilisateurs avec des tokens d'accès et de refresh.",
+    summary:
+      'Authentification JWT avec rotation de refresh token, hashage bcrypt et middleware de protection.',
+  },
+  {
+    key: 'userCrud',
+    name: 'Gestion CRUD des utilisateurs',
+    description:
+      'Expose des routes sécurisées pour administrer le cycle de vie des utilisateurs (listing, création, mise à jour, suppression).',
+    summary:
+      'CRUD complet des utilisateurs avec validation, découpage en cas d\'usage et repository en mémoire.',
+    dependencies: ['auth'],
+  },
+  {
+    key: 'clientPortal',
+    name: 'Espace client',
+    description:
+      'Ajoute un espace client dédié avec routes protégées et autorisations basées sur le rôle.',
+    summary: 'Espace client prêt à l\'emploi avec contrôleurs dédiés et contrôle de rôle.',
+    dependencies: ['auth'],
+  },
+  {
+    key: 'adminPortal',
+    name: 'Espace administrateur',
+    description:
+      'Ajoute un espace d\'administration séparé pour gérer la plateforme avec contrôle d\'accès renforcé.',
+    summary: 'Espace administrateur sécurisé avec endpoints dédiés et vérification stricte du rôle.',
+    dependencies: ['auth'],
+  },
+];
+
+export const featureCatalogMap = new Map(featureCatalog.map((feature) => [feature.key, feature]));
+
+export function resolveFeatureDependencies(selected: FeatureKey[]): FeatureKey[] {
+  const resolved = new Set<FeatureKey>();
+
+  function visit(featureKey: FeatureKey) {
+    if (resolved.has(featureKey)) {
+      return;
+    }
+
+    const feature = featureCatalogMap.get(featureKey);
+    if (!feature) {
+      throw new Error(`Unknown feature: ${featureKey}`);
+    }
+
+    feature.dependencies?.forEach(visit);
+    resolved.add(featureKey);
+  }
+
+  selected.forEach(visit);
+
+  return Array.from(resolved);
+}

--- a/src/cli/generators/typescript-generator.ts
+++ b/src/cli/generators/typescript-generator.ts
@@ -1,0 +1,90 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import { BaseTemplateGenerator, GenerateProjectOptions, TemplateDependencies } from './base-generator';
+import { FeatureKey, Language } from './types';
+
+const templateRoot = path.resolve(__dirname, '../../..', 'templates', 'typescript');
+
+export class TypeScriptTemplateGenerator extends BaseTemplateGenerator {
+  constructor() {
+    super(templateRoot);
+  }
+
+  protected getBaseTemplateDir(): string {
+    return path.join(templateRoot, 'base');
+  }
+
+  protected getFeatureTemplateDir(feature: FeatureKey): string | undefined {
+    const featurePath = path.join(templateRoot, 'features', feature);
+    return fs.existsSync(featurePath) ? featurePath : undefined;
+  }
+
+  protected buildDependencies(_language: Language, features: FeatureKey[]): TemplateDependencies {
+    const dependencies = [
+      { name: 'cors', version: '^2.8.5' },
+      { name: 'dotenv', version: '^16.4.1' },
+      { name: 'express', version: '^4.18.2' },
+      { name: 'express-rate-limit', version: '^6.11.2' },
+      { name: 'helmet', version: '^7.0.0' },
+      { name: 'pino', version: '^8.16.1' },
+      { name: 'pino-http', version: '^9.0.1' },
+      { name: 'pino-pretty', version: '^10.3.1' },
+      { name: 'swagger-ui-express', version: '^5.0.0' },
+      { name: 'zod', version: '^3.22.4' },
+    ];
+
+    const devDependencies = [
+      { name: '@types/cors', version: '^2.8.17' },
+      { name: '@types/express', version: '^4.17.21' },
+      { name: '@types/express-rate-limit', version: '^5.1.3' },
+      { name: '@types/jest', version: '^29.5.12' },
+      { name: '@types/node', version: '^20.11.20' },
+      { name: '@types/supertest', version: '^2.0.16' },
+      { name: '@types/swagger-ui-express', version: '^4.1.3' },
+      { name: 'openapi-types', version: '^12.1.3' },
+      { name: '@typescript-eslint/eslint-plugin', version: '^6.21.0' },
+      { name: '@typescript-eslint/parser', version: '^6.21.0' },
+      { name: 'eslint', version: '^8.56.0' },
+      { name: 'eslint-config-prettier', version: '^9.1.0' },
+      { name: 'jest', version: '^29.7.0' },
+      { name: 'prettier', version: '^3.2.5' },
+      { name: 'supertest', version: '^7.1.1' },
+      { name: 'ts-jest', version: '^29.1.2' },
+      { name: 'ts-node', version: '^10.9.2' },
+      { name: 'ts-node-dev', version: '^2.0.0' },
+      { name: 'typescript', version: '^5.4.2' },
+    ];
+
+    if (features.includes('auth')) {
+      dependencies.push({ name: 'bcryptjs', version: '^2.4.3' });
+      dependencies.push({ name: 'jsonwebtoken', version: '^9.0.2' });
+      devDependencies.push({ name: '@types/jsonwebtoken', version: '^9.0.6' });
+    }
+
+    const scripts: Record<string, string> = {
+      dev: 'ts-node-dev --respawn --transpile-only --ignore-watch node_modules --no-notify src/server.ts',
+      build: 'tsc -p tsconfig.json',
+      start: 'node dist/server.js',
+      test: 'jest --passWithNoTests',
+      'test:watch': 'jest --watch',
+      lint: 'eslint "src/**/*.{ts,tsx}"',
+      format: 'prettier --write "src/**/*.{ts,tsx}"',
+    };
+
+    return {
+      dependencies,
+      devDependencies,
+      scripts,
+    };
+  }
+
+  protected getAdditionalContext(options: GenerateProjectOptions, _dependencies: TemplateDependencies) {
+    return {
+      isTypeScript: true,
+      hasAuth: options.features.includes('auth'),
+      hasUserCrud: options.features.includes('userCrud'),
+      hasClientPortal: options.features.includes('clientPortal'),
+      hasAdminPortal: options.features.includes('adminPortal'),
+    };
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import path from 'node:path';
+import chalk from 'chalk';
+import { runCreateCommand } from './commands/create';
+import { FeatureKey, Language, featureCatalog } from './generators/types';
+
+function getPackageVersion(): string {
+  try {
+    const packageJsonPath = path.resolve(__dirname, '../../package.json');
+    const packageJson = fs.readJsonSync(packageJsonPath);
+    return packageJson.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function parseFeaturesOption(input?: string): FeatureKey[] | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  const normalized = input
+    .split(/[,\s]+/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return normalized as FeatureKey[];
+}
+
+function isLanguage(value: string): value is Language {
+  return value === 'typescript' || value === 'javascript';
+}
+
+async function main() {
+  const program = new Command();
+  const version = getPackageVersion();
+
+  program
+    .name('create-template-api')
+    .description("Générateur d'API hexagonale modulaire sans base de données.")
+    .version(version);
+
+  program
+    .argument('[directory]', 'Répertoire cible (sera créé s\'il n\'existe pas).')
+    .option('-n, --name <name>', 'Nom du projet. (par défaut : nom du dossier)')
+    .option('-l, --language <language>', 'Langage cible (typescript|javascript)')
+    .option('-f, --features <features>', 'Modules à activer (séparés par des virgules).')
+    .option('-p, --package-manager <manager>', 'Gestionnaire de packages (npm|pnpm|yarn).')
+    .option('--dry-run', 'Affiche les actions sans écrire les fichiers.')
+    .action(async (directory: string | undefined, commandOptions: Record<string, unknown>) => {
+      const languageOption = typeof commandOptions.language === 'string' ? commandOptions.language : undefined;
+      const featuresOption = typeof commandOptions.features === 'string' ? commandOptions.features : undefined;
+      const packageManagerOption = typeof commandOptions.packageManager === 'string' ? commandOptions.packageManager : undefined;
+      const dryRun = Boolean(commandOptions.dryRun);
+
+      if (languageOption && !isLanguage(languageOption)) {
+        throw new Error(
+          `Langage inconnu : ${languageOption}. Valeurs possibles : ${['typescript', 'javascript'].join(', ')}`
+        );
+      }
+
+      const selectedFeatures = parseFeaturesOption(featuresOption);
+      if (selectedFeatures) {
+        const availableKeys = new Set(featureCatalog.map((feature) => feature.key));
+        const unknownFeatures = selectedFeatures.filter((feature) => !availableKeys.has(feature));
+        if (unknownFeatures.length > 0) {
+          throw new Error(
+            `Modules inconnus : ${unknownFeatures.join(', ')}. Modules disponibles : ${featureCatalog
+              .map((feature) => feature.key)
+              .join(', ')}`
+          );
+        }
+      }
+
+      await runCreateCommand(directory, {
+        projectName: typeof commandOptions.name === 'string' ? commandOptions.name : undefined,
+        language: languageOption as Language | undefined,
+        features: selectedFeatures,
+        packageManager: packageManagerOption as 'npm' | 'pnpm' | 'yarn' | undefined,
+        dryRun,
+      });
+    });
+
+  program.parseAsync(process.argv).catch((error) => {
+    console.error('\n' + chalk.red(`\u274c ${error.message}`));
+    process.exit(1);
+  });
+}
+
+main();

--- a/src/cli/prompts/prompts.ts
+++ b/src/cli/prompts/prompts.ts
@@ -1,0 +1,100 @@
+import inquirer from 'inquirer';
+import {
+  FeatureKey,
+  Language,
+  featureCatalog,
+  featureCatalogMap,
+  resolveFeatureDependencies,
+} from '../generators/types';
+
+export interface PromptAnswers {
+  projectName: string;
+  language: Language;
+  features: FeatureKey[];
+  packageManager: 'npm' | 'pnpm' | 'yarn';
+}
+
+export interface PromptOptions {
+  projectName?: string;
+  language?: Language;
+  features?: FeatureKey[];
+  packageManager?: 'npm' | 'pnpm' | 'yarn';
+}
+
+export async function promptForMissingOptions(options: PromptOptions): Promise<PromptAnswers> {
+  const questions: inquirer.QuestionCollection[] = [];
+
+  if (!options.projectName) {
+    questions.push({
+      type: 'input',
+      name: 'projectName',
+      message: 'Nom du projet :',
+      validate: (input: string) => (input.trim().length > 0 ? true : 'Le nom du projet est obligatoire.'),
+    });
+  }
+
+  if (!options.language) {
+    questions.push({
+      type: 'list',
+      name: 'language',
+      message: 'Choisissez un langage :',
+      default: 'typescript',
+      choices: [
+        { name: 'TypeScript (recommandé)', value: 'typescript' },
+        { name: 'JavaScript (ESM)', value: 'javascript' },
+      ],
+    });
+  }
+
+  if (!options.features) {
+    questions.push({
+      type: 'checkbox',
+      name: 'features',
+      message: 'Sélectionnez les modules à inclure :',
+      choices: featureCatalog.map((feature) => ({
+        name: `${feature.name} — ${feature.description}`,
+        value: feature.key,
+      })),
+      default: ['auth'],
+      validate: (selected: FeatureKey[]) =>
+        selected.length > 0 ? true : 'Sélectionnez au moins un module pour démarrer.',
+    });
+  }
+
+  if (!options.packageManager) {
+    questions.push({
+      type: 'list',
+      name: 'packageManager',
+      message: 'Quel gestionnaire de packages souhaitez-vous utiliser ?',
+      default: 'npm',
+      choices: [
+        { name: 'npm', value: 'npm' },
+        { name: 'pnpm', value: 'pnpm' },
+        { name: 'yarn', value: 'yarn' },
+      ],
+    });
+  }
+
+  const answers = await inquirer.prompt(questions);
+
+  const projectName = options.projectName ?? answers.projectName;
+  const language = options.language ?? answers.language;
+  const rawFeatures: FeatureKey[] = options.features ?? answers.features;
+  const resolvedFeatures = resolveFeatureDependencies(rawFeatures);
+  const packageManager = options.packageManager ?? answers.packageManager;
+
+  const missingDependencies = resolvedFeatures.filter((featureKey) =>
+    featureCatalogMap.get(featureKey)?.dependencies?.some((dependency) => !resolvedFeatures.includes(dependency))
+  );
+
+  if (missingDependencies.length > 0) {
+    throw new Error(`Impossible de résoudre les dépendances des modules : ${missingDependencies.join(', ')}`);
+  }
+
+  return {
+    projectName,
+    language,
+    features: resolvedFeatures,
+    packageManager,
+  };
+}

--- a/templates/javascript/base/.env.example.ejs
+++ b/templates/javascript/base/.env.example.ejs
@@ -1,0 +1,12 @@
+APP_NAME=<%- projectName %>
+API_PORT=3333
+CORS_ORIGIN=*
+LOG_LEVEL=info
+RATE_LIMIT_WINDOW_MINUTES=15
+RATE_LIMIT_MAX_REQUESTS=120
+<% if (features.includes('auth')) { %>
+JWT_SECRET=change-me-access
+JWT_REFRESH_SECRET=change-me-refresh
+ACCESS_TOKEN_TTL=15m
+REFRESH_TOKEN_TTL=7d
+<% } %>

--- a/templates/javascript/base/.eslintrc.cjs.ejs
+++ b/templates/javascript/base/.eslintrc.cjs.ejs
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  extends: ['eslint:recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: 'script',
+  },
+  rules: {},
+};

--- a/templates/javascript/base/.gitignore.ejs
+++ b/templates/javascript/base/.gitignore.ejs
@@ -1,0 +1,8 @@
+node_modules
+.env
+.env.local
+coverage
+.DS_Store
+*.log
+.vscode
+.idea

--- a/templates/javascript/base/.prettierrc.cjs.ejs
+++ b/templates/javascript/base/.prettierrc.cjs.ejs
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  tabWidth: 2,
+};

--- a/templates/javascript/base/Dockerfile.ejs
+++ b/templates/javascript/base/Dockerfile.ejs
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN set -eux; \
+  if [ -f pnpm-lock.yaml ]; then \
+    npm install -g pnpm && pnpm install --frozen-lockfile; \
+  elif [ -f yarn.lock ]; then \
+    yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then \
+    npm ci; \
+  else \
+    npm install; \
+  fi
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+EXPOSE 3333
+CMD ["node", "src/server.js"]

--- a/templates/javascript/base/README.md.ejs
+++ b/templates/javascript/base/README.md.ejs
@@ -1,0 +1,58 @@
+# <%- projectName %>
+
+Généré avec **create-template-api** le <%- createdAt %>.
+
+## 🚀 Modules inclus
+
+- Express configuré avec Helmet, CORS, rate limiting et logging Pino.
+- Validation des entrées via Zod et gestion centralisée des erreurs.
+- Documentation OpenAPI servie sur `/docs` et collection Insomnia.
+<% if (featureSummaries.length) { %>
+<% featureSummaries.forEach((summary) => { %>- <%- summary %>
+<% }); %>
+<% } %>
+
+## 🗂 Architecture hexagonale
+
+```
+src/
+├── domain/           # Modèle métier et contrats
+├── application/      # Cas d'usage, services, erreurs
+├── infrastructure/   # Adaptateurs techniques & conteneur
+└── interface/http/   # Routes, contrôleurs, middlewares, docs
+```
+
+## 🔧 Installation & exécution
+
+```bash
+<%- packageManagerCommands.install %>
+<%- packageManagerCommands.run %> dev
+```
+
+### Scripts utiles
+
+| Script | Commande |
+| ------ | -------- |
+<% Object.entries(scripts).forEach(([name, command]) => { %>| <%- name %> | `<%- command %>` |
+<% }); %>
+
+## 📚 Documentation
+
+- Swagger/OpenAPI sur [`/docs`](http://localhost:3333/docs)
+- Collection Insomnia : `docs/insomnia/collection.json`
+
+## 🧪 Tests
+
+```bash
+<%- packageManagerCommands.run %> test
+```
+
+## 🛡 Bonnes pratiques
+
+- Middleware de sécurité activés par défaut
+- Logs structurés via Pino + Pino-pretty en développement
+- Validation d'entrée systématique et réponses d'erreur homogènes
+<% if (features.includes('auth')) { %>- Authentification JWT + rotation de refresh token
+<% } %>
+
+Bon développement ! 🚀

--- a/templates/javascript/base/docker-compose.yml.ejs
+++ b/templates/javascript/base/docker-compose.yml.ejs
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - '3333:3333'
+    environment:
+      NODE_ENV: development
+      API_PORT: 3333
+      CORS_ORIGIN: '*'
+      LOG_LEVEL: info
+<% if (features.includes('auth')) { %>
+      JWT_SECRET: change-me-access
+      JWT_REFRESH_SECRET: change-me-refresh
+      ACCESS_TOKEN_TTL: 15m
+      REFRESH_TOKEN_TTL: 7d
+<% } %>
+    volumes:
+      - ./:/app
+    command: npm run dev

--- a/templates/javascript/base/docs/insomnia/collection.json.ejs
+++ b/templates/javascript/base/docs/insomnia/collection.json.ejs
@@ -1,0 +1,124 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "<%- createdAt %>",
+  "resources": [
+    {
+      "_id": "wrk_<%- packageName %>",
+      "_type": "workspace",
+      "name": "<%- projectName %>",
+      "description": "Collection générée pour tester l'API <%- projectName %>."
+    },
+    {
+      "_id": "req_health_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Health",
+      "method": "GET",
+      "url": "{{ base_url }}/health"
+    }
+<% if (features.includes('auth')) { %>
+    ,{
+      "_id": "req_register_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Register",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/register",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"name\": \"Ada Lovelace\",\n  \"email\": \"ada@example.com\",\n  \"password\": \"Str0ng#Pass\"\n}"
+      }
+    },
+    {
+      "_id": "req_login_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Login",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/login",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"email\": \"ada@example.com\",\n  \"password\": \"Str0ng#Pass\"\n}"
+      }
+    },
+    {
+      "_id": "req_refresh_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Refresh",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/refresh",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"refreshToken\": \"<refreshToken>\"\n}"
+      }
+    },
+    {
+      "_id": "req_me_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Profile",
+      "method": "GET",
+      "url": "{{ base_url }}/me",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <accessToken>" }
+      ]
+    }
+<% } %>
+<% if (features.includes('userCrud')) { %>
+    ,{
+      "_id": "req_users_list_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Users",
+      "method": "GET",
+      "url": "{{ base_url }}/users",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ]
+    },
+    {
+      "_id": "req_users_create_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST User",
+      "method": "POST",
+      "url": "{{ base_url }}/users",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ],
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"name\": \"New User\",\n  \"email\": \"new@example.com\",\n  \"password\": \"Temp#1234\",\n  \"role\": \"client\"\n}"
+      }
+    }
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+    ,{
+      "_id": "req_client_dashboard_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Client Dashboard",
+      "method": "GET",
+      "url": "{{ base_url }}/client/dashboard",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <clientToken>" }
+      ]
+    }
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+    ,{
+      "_id": "req_admin_dashboard_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Admin Dashboard",
+      "method": "GET",
+      "url": "{{ base_url }}/admin/dashboard",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ]
+    }
+<% } %>
+  ]
+}

--- a/templates/javascript/base/jest.config.js.ejs
+++ b/templates/javascript/base/jest.config.js.ejs
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/tests/**/*.spec.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup-env.js'],
+  collectCoverageFrom: ['src/**/*.js'],
+  coveragePathIgnorePatterns: ['/node_modules/'],
+};

--- a/templates/javascript/base/package.json.ejs
+++ b/templates/javascript/base/package.json.ejs
@@ -1,0 +1,27 @@
+{
+  "name": "<%- packageName %>",
+  "version": "0.1.0",
+  "private": true,
+  "description": "API Node.js générée avec create-template-api.",
+  "main": "src/server.js",
+  "type": "commonjs",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "scripts": {
+<% Object.entries(scripts).forEach(([name, command], index, array) => { %>
+    "<%- name %>": "<%- command %>"<%= index < array.length - 1 ? ',' : '' %>
+<% }); %>
+  },
+  "dependencies": {
+<% dependencies.forEach((dependency, index) => { %>
+    "<%- dependency.name %>": "<%- dependency.version %>"<%= index < dependencies.length - 1 ? ',' : '' %>
+<% }); %>
+  },
+  "devDependencies": {
+<% devDependencies.forEach((dependency, index) => { %>
+    "<%- dependency.name %>": "<%- dependency.version %>"<%= index < devDependencies.length - 1 ? ',' : '' %>
+<% }); %>
+  }
+}

--- a/templates/typescript/base/.env.example.ejs
+++ b/templates/typescript/base/.env.example.ejs
@@ -1,0 +1,12 @@
+APP_NAME=<%- projectName %>
+API_PORT=3333
+CORS_ORIGIN=*
+LOG_LEVEL=info
+RATE_LIMIT_WINDOW_MINUTES=15
+RATE_LIMIT_MAX_REQUESTS=120
+<% if (features.includes('auth')) { %>
+JWT_SECRET=change-me-access
+JWT_REFRESH_SECRET=change-me-refresh
+ACCESS_TOKEN_TTL=15m
+REFRESH_TOKEN_TTL=7d
+<% } %>

--- a/templates/typescript/base/.eslintrc.cjs.ejs
+++ b/templates/typescript/base/.eslintrc.cjs.ejs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'prettier',
+  ],
+  rules: {
+    '@typescript-eslint/no-misused-promises': [
+      'error',
+      { checksVoidReturn: false },
+    ],
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+  },
+};

--- a/templates/typescript/base/.gitignore.ejs
+++ b/templates/typescript/base/.gitignore.ejs
@@ -1,0 +1,10 @@
+node_modules
+.env
+.env.local
+coverage
+dist
+.tmp
+.DS_Store
+*.log
+.idea
+.vscode

--- a/templates/typescript/base/.prettierrc.cjs.ejs
+++ b/templates/typescript/base/.prettierrc.cjs.ejs
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  tabWidth: 2,
+};

--- a/templates/typescript/base/Dockerfile.ejs
+++ b/templates/typescript/base/Dockerfile.ejs
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN set -eux; \
+  if [ -f pnpm-lock.yaml ]; then \
+    npm install -g pnpm && pnpm install --frozen-lockfile; \
+  elif [ -f yarn.lock ]; then \
+    yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then \
+    npm ci; \
+  else \
+    npm install; \
+  fi
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package.json ./
+EXPOSE 3333
+CMD ["node", "dist/server.js"]

--- a/templates/typescript/base/README.md.ejs
+++ b/templates/typescript/base/README.md.ejs
@@ -1,0 +1,70 @@
+# <%- projectName %>
+
+Généré avec **create-template-api** le <%- createdAt %>.
+
+## 🚀 Modules inclus
+
+- Sécurité HTTP (Helmet, CORS, rate limiting) et logging Pino.
+- Validation des entrées avec Zod et middleware de gestion d'erreurs.
+- Documentation OpenAPI servie sur `/docs` et collection Insomnia.
+<% if (featureSummaries.length) { %>
+<% featureSummaries.forEach((summary) => { %>- <%- summary %>
+<% }); %>
+<% } %>
+
+## 🗂 Architecture hexagonale
+
+```
+src/
+├── domain/           # Modèle métier et contrats
+├── application/      # Cas d'usage, services et erreurs
+├── infrastructure/   # Adapters, configuration et conteneur d'injection
+└── interface/http/   # Routes, contrôleurs, middlewares, docs et DTOs
+```
+
+Chaque couche ne dépend que de la précédente afin de garantir testabilité et évolutivité.
+
+## 🔧 Installation & exécution
+
+```bash
+<%- packageManagerCommands.install %>
+<%- packageManagerCommands.run %> dev
+```
+
+### Principaux scripts
+
+| Script | Commande |
+| ------ | -------- |
+<% Object.entries(scripts).forEach(([name, command]) => { %>| <%- name %> | `<%- command %>` |
+<% }); %>
+
+## 📚 Documentation
+
+- Swagger/OpenAPI disponible sur [`/docs`](http://localhost:3333/docs).
+- Collection Insomnia générée dans `docs/insomnia/collection.json`.
+
+## 🧪 Tests
+
+```bash
+<%- packageManagerCommands.run %> test
+```
+
+Les tests reposent sur Jest et Supertest. Des doubles in-memory permettent d'isoler les cas d'usage des dépendances.
+
+## 🛡 Sécurité & bonnes pratiques
+
+- Middleware globaux : Helmet, CORS configurables, rate limiting.
+- Journalisation structurée via Pino (pretty logging en développement).
+- Validation centralisée avec Zod et réponses d'erreur normalisées.
+<% if (features.includes('auth')) { %>- Tokens JWT signés, rotation de refresh token et hashage des mots de passe.
+<% } %>
+<% if (features.includes('clientPortal') || features.includes('adminPortal')) { %>- Contrôle d'accès basé sur les rôles pour les espaces dédiés.
+<% } %>
+
+## ▶️ Aller plus loin
+
+- Ajoutez de nouveaux cas d'usage dans `src/application/use-cases`.
+- Implémentez vos propres adaptateurs (email, files, etc.) dans `src/infrastructure`.
+- Étendez la documentation via `src/interface/http/docs/openapi.ts`.
+
+Bon développement ! 🚀

--- a/templates/typescript/base/docker-compose.yml.ejs
+++ b/templates/typescript/base/docker-compose.yml.ejs
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - '3333:3333'
+    environment:
+      NODE_ENV: development
+      API_PORT: 3333
+      CORS_ORIGIN: '*'
+      LOG_LEVEL: info
+<% if (features.includes('auth')) { %>
+      JWT_SECRET: change-me-access
+      JWT_REFRESH_SECRET: change-me-refresh
+      ACCESS_TOKEN_TTL: 15m
+      REFRESH_TOKEN_TTL: 7d
+<% } %>
+    volumes:
+      - ./:/app
+    command: npm run dev

--- a/templates/typescript/base/docs/insomnia/collection.json.ejs
+++ b/templates/typescript/base/docs/insomnia/collection.json.ejs
@@ -1,0 +1,124 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "<%- createdAt %>",
+  "resources": [
+    {
+      "_id": "wrk_<%- packageName %>",
+      "_type": "workspace",
+      "name": "<%- projectName %>",
+      "description": "Collection générée pour tester l'API <%- projectName %>."
+    },
+    {
+      "_id": "req_health_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Health",
+      "method": "GET",
+      "url": "{{ base_url }}/health"
+    }
+<% if (features.includes('auth')) { %>
+    ,{
+      "_id": "req_register_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Register",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/register",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"name\": \"Ada Lovelace\",\n  \"email\": \"ada@example.com\",\n  \"password\": \"Str0ng#Pass\"\n}"
+      }
+    },
+    {
+      "_id": "req_login_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Login",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/login",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"email\": \"ada@example.com\",\n  \"password\": \"Str0ng#Pass\"\n}"
+      }
+    },
+    {
+      "_id": "req_refresh_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST Refresh",
+      "method": "POST",
+      "url": "{{ base_url }}/auth/refresh",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"refreshToken\": \"<refreshToken>\"\n}"
+      }
+    },
+    {
+      "_id": "req_me_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Profile",
+      "method": "GET",
+      "url": "{{ base_url }}/me",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <accessToken>" }
+      ]
+    }
+<% } %>
+<% if (features.includes('userCrud')) { %>
+    ,{
+      "_id": "req_users_list_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Users",
+      "method": "GET",
+      "url": "{{ base_url }}/users",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ]
+    },
+    {
+      "_id": "req_users_create_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "POST User",
+      "method": "POST",
+      "url": "{{ base_url }}/users",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ],
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"name\": \"New User\",\n  \"email\": \"new@example.com\",\n  \"password\": \"Temp#1234\",\n  \"role\": \"client\"\n}"
+      }
+    }
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+    ,{
+      "_id": "req_client_dashboard_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Client Dashboard",
+      "method": "GET",
+      "url": "{{ base_url }}/client/dashboard",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <clientToken>" }
+      ]
+    }
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+    ,{
+      "_id": "req_admin_dashboard_<%- packageName %>",
+      "_type": "request",
+      "parentId": "wrk_<%- packageName %>",
+      "name": "GET Admin Dashboard",
+      "method": "GET",
+      "url": "{{ base_url }}/admin/dashboard",
+      "headers": [
+        { "name": "Authorization", "value": "Bearer <adminToken>" }
+      ]
+    }
+<% } %>
+  ]
+}

--- a/templates/typescript/base/jest.config.ts.ejs
+++ b/templates/typescript/base/jest.config.ts.ejs
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/tests/**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup-env.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
+};
+
+export default config;

--- a/templates/typescript/base/package.json.ejs
+++ b/templates/typescript/base/package.json.ejs
@@ -1,0 +1,27 @@
+{
+  "name": "<%- packageName %>",
+  "version": "0.1.0",
+  "private": true,
+  "description": "API hexagonale modulaire générée avec create-template-api.",
+  "main": "dist/server.js",
+  "type": "commonjs",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.17.0"
+  },
+  "scripts": {
+<% Object.entries(scripts).forEach(([name, command], index, array) => { %>
+    "<%- name %>": "<%- command %>"<%= index < array.length - 1 ? ',' : '' %>
+<% }); %>
+  },
+  "dependencies": {
+<% dependencies.forEach((dependency, index) => { %>
+    "<%- dependency.name %>": "<%- dependency.version %>"<%= index < dependencies.length - 1 ? ',' : '' %>
+<% }); %>
+  },
+  "devDependencies": {
+<% devDependencies.forEach((dependency, index) => { %>
+    "<%- dependency.name %>": "<%- dependency.version %>"<%= index < devDependencies.length - 1 ? ',' : '' %>
+<% }); %>
+  }
+}

--- a/templates/typescript/base/src/application/errors/application-error.ts.ejs
+++ b/templates/typescript/base/src/application/errors/application-error.ts.ejs
@@ -1,0 +1,6 @@
+export class ApplicationError extends Error {
+  constructor(message: string, public readonly statusCode = 400, public readonly context?: unknown) {
+    super(message);
+    this.name = 'ApplicationError';
+  }
+}

--- a/templates/typescript/base/src/application/errors/conflict-error.ts.ejs
+++ b/templates/typescript/base/src/application/errors/conflict-error.ts.ejs
@@ -1,0 +1,8 @@
+import { ApplicationError } from './application-error';
+
+export class ConflictError extends ApplicationError {
+  constructor(message: string) {
+    super(message, 409);
+    this.name = 'ConflictError';
+  }
+}

--- a/templates/typescript/base/src/application/errors/not-found-error.ts.ejs
+++ b/templates/typescript/base/src/application/errors/not-found-error.ts.ejs
@@ -1,0 +1,8 @@
+import { ApplicationError } from './application-error';
+
+export class NotFoundError extends ApplicationError {
+  constructor(message = 'Resource not found') {
+    super(message, 404);
+    this.name = 'NotFoundError';
+  }
+}

--- a/templates/typescript/base/src/application/errors/validation-error.ts.ejs
+++ b/templates/typescript/base/src/application/errors/validation-error.ts.ejs
@@ -1,0 +1,9 @@
+import { ZodError } from 'zod';
+import { ApplicationError } from './application-error';
+
+export class ValidationError extends ApplicationError {
+  constructor(public readonly error: ZodError) {
+    super('Validation error', 422, error.flatten());
+    this.name = 'ValidationError';
+  }
+}

--- a/templates/typescript/base/src/infrastructure/config/env.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/config/env.ts.ejs
@@ -1,0 +1,21 @@
+import 'dotenv/config';
+import { z } from 'zod';
+
+const envSchema = z.object({
+  APP_NAME: z.string().default('<%- projectName %>'),
+  API_PORT: z.coerce.number().default(3333),
+  CORS_ORIGIN: z.string().default('*'),
+  LOG_LEVEL: z.string().default('info'),
+  RATE_LIMIT_WINDOW_MINUTES: z.coerce.number().default(15),
+  RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(120),
+<% if (features.includes('auth')) { %>
+  JWT_SECRET: z.string().min(32, 'JWT_SECRET doit contenir au moins 32 caractères.'),
+  JWT_REFRESH_SECRET: z.string().min(32, 'JWT_REFRESH_SECRET doit contenir au moins 32 caractères.'),
+  ACCESS_TOKEN_TTL: z.string().default('15m'),
+  REFRESH_TOKEN_TTL: z.string().default('7d'),
+<% } %>
+});
+
+type Env = z.infer<typeof envSchema>;
+
+export const env: Env = envSchema.parse(process.env);

--- a/templates/typescript/base/src/infrastructure/container.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/container.ts.ejs
@@ -1,0 +1,114 @@
+import { logger } from './logging/logger';
+<% if (features.includes('auth')) { %>
+import { InMemoryUserRepository } from './persistence/in-memory/in-memory-user.repository';
+import { InMemoryRefreshTokenRepository } from './persistence/in-memory/in-memory-refresh-token.repository';
+import { BcryptPasswordHasher } from './hashing/bcrypt-password-hasher';
+import { JwtTokenService } from './auth/jwt-token.service';
+import { RegisterUserUseCase } from '../application/use-cases/auth/register-user.usecase';
+import { AuthenticateUserUseCase } from '../application/use-cases/auth/authenticate-user.usecase';
+import { RefreshTokenUseCase } from '../application/use-cases/auth/refresh-token.usecase';
+import { LogoutUserUseCase } from '../application/use-cases/auth/logout-user.usecase';
+import { GetProfileUseCase } from '../application/use-cases/auth/get-profile.usecase';
+import { createUser } from '../domain/entities/user';
+import bcrypt from 'bcryptjs';
+<% if (features.includes('userCrud')) { %>
+import { ListUsersUseCase } from '../application/use-cases/users/list-users.usecase';
+import { GetUserUseCase } from '../application/use-cases/users/get-user.usecase';
+import { CreateUserUseCase } from '../application/use-cases/users/create-user.usecase';
+import { UpdateUserUseCase } from '../application/use-cases/users/update-user.usecase';
+import { DeleteUserUseCase } from '../application/use-cases/users/delete-user.usecase';
+<% } %>
+<% } %>
+
+class AppContainer {
+  readonly logger = logger;
+<% if (features.includes('auth')) { %>
+  readonly userRepository = new InMemoryUserRepository();
+  readonly refreshTokenRepository = new InMemoryRefreshTokenRepository();
+  readonly passwordHasher = new BcryptPasswordHasher();
+  readonly tokenService = new JwtTokenService(this.refreshTokenRepository, this.userRepository);
+<% } %>
+}
+
+export const container = new AppContainer();
+
+<% if (features.includes('auth')) { %>
+async function seedInitialUsers() {
+  const users = await container.userRepository.list();
+
+  if (users.length === 0) {
+    const adminPassword = bcrypt.hashSync('Admin#1234', 10);
+    const clientPassword = bcrypt.hashSync('Client#1234', 10);
+
+    await container.userRepository.create(
+      createUser({
+        name: 'Administrator',
+        email: 'admin@example.com',
+        passwordHash: adminPassword,
+        role: 'admin',
+      })
+    );
+
+    await container.userRepository.create(
+      createUser({
+        name: 'Client Demo',
+        email: 'client@example.com',
+        passwordHash: clientPassword,
+        role: 'client',
+      })
+    );
+  }
+}
+
+export const containerReady = seedInitialUsers();
+
+export function makeRegisterUserUseCase() {
+  return new RegisterUserUseCase(container.userRepository, container.passwordHasher, container.tokenService);
+}
+
+export function makeAuthenticateUserUseCase() {
+  return new AuthenticateUserUseCase(container.userRepository, container.passwordHasher, container.tokenService);
+}
+
+export function makeRefreshTokenUseCase() {
+  return new RefreshTokenUseCase(container.tokenService);
+}
+
+export function makeLogoutUserUseCase() {
+  return new LogoutUserUseCase(container.tokenService);
+}
+
+export function makeGetProfileUseCase() {
+  return new GetProfileUseCase(container.userRepository);
+}
+
+export function resolveTokenService() {
+  return container.tokenService;
+}
+
+export function resolveUserRepository() {
+  return container.userRepository;
+}
+
+<% if (features.includes('userCrud')) { %>
+export function makeListUsersUseCase() {
+  return new ListUsersUseCase(container.userRepository);
+}
+
+export function makeGetUserUseCase() {
+  return new GetUserUseCase(container.userRepository);
+}
+
+export function makeCreateUserUseCase() {
+  return new CreateUserUseCase(container.userRepository, container.passwordHasher);
+}
+
+export function makeUpdateUserUseCase() {
+  return new UpdateUserUseCase(container.userRepository, container.passwordHasher);
+}
+
+export function makeDeleteUserUseCase() {
+  return new DeleteUserUseCase(container.userRepository, container.refreshTokenRepository);
+}
+<% } %>
+<% } %>

--- a/templates/typescript/base/src/infrastructure/logging/logger.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/logging/logger.ts.ejs
@@ -1,0 +1,23 @@
+import pino from 'pino';
+import pinoHttp from 'pino-http';
+import { env } from '../config/env';
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  transport: isDevelopment
+    ? {
+        target: 'pino-pretty',
+        options: {
+          translateTime: 'HH:MM:ss',
+          ignore: 'pid,hostname',
+        },
+      }
+    : undefined,
+});
+
+export const httpLogger = pinoHttp({
+  logger,
+  autoLogging: true,
+});

--- a/templates/typescript/base/src/interface/http/app.ts.ejs
+++ b/templates/typescript/base/src/interface/http/app.ts.ejs
@@ -1,0 +1,40 @@
+import cors from 'cors';
+import express from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import { env } from '../../infrastructure/config/env';
+import { httpLogger } from '../../infrastructure/logging/logger';
+import { routes } from './routes';
+import { errorHandler } from './middlewares/error-handler';
+import { notFoundHandler } from './middlewares/not-found-handler';
+import { registerDocs } from './docs/swagger';
+
+export function createApp() {
+  const app = express();
+
+<% if (features.includes('auth')) { %>
+  app.set('trust proxy', 1);
+<% } %>
+  app.use(helmet());
+  app.use(cors({
+    origin: env.CORS_ORIGIN === '*' ? true : env.CORS_ORIGIN.split(',').map((origin) => origin.trim()),
+  }));
+  app.use(express.json());
+  app.use(httpLogger);
+
+  app.use(
+    rateLimit({
+      windowMs: env.RATE_LIMIT_WINDOW_MINUTES * 60 * 1000,
+      max: env.RATE_LIMIT_MAX_REQUESTS,
+      standardHeaders: true,
+      legacyHeaders: false,
+    })
+  );
+
+  registerDocs(app);
+  app.use(routes);
+  app.use(notFoundHandler);
+  app.use(errorHandler);
+
+  return app;
+}

--- a/templates/typescript/base/src/interface/http/controllers/health.controller.ts.ejs
+++ b/templates/typescript/base/src/interface/http/controllers/health.controller.ts.ejs
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+
+class HealthController {
+  handle(_request: Request, response: Response) {
+    return response.json({
+      status: 'ok',
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+
+export const healthController = new HealthController();

--- a/templates/typescript/base/src/interface/http/docs/openapi.ts.ejs
+++ b/templates/typescript/base/src/interface/http/docs/openapi.ts.ejs
@@ -1,0 +1,422 @@
+import type { OpenAPIV3 } from 'openapi-types';
+
+export const openApiDocument: OpenAPIV3.Document = {
+  openapi: '3.0.3',
+  info: {
+    title: '<%- projectName %>',
+    version: '1.0.0',
+    description: 'API générée avec create-template-api.',
+  },
+  servers: [{ url: 'http://localhost:3333', description: 'Local' }],
+  tags: [
+    { name: 'Health', description: 'Monitoring et disponibilité de l\'API.' },
+<% if (features.includes('auth')) { %>
+    { name: 'Auth', description: 'Inscription, connexion et gestion des tokens.' },
+    { name: 'Profile', description: 'Profil de l\'utilisateur courant.' },
+<% } %>
+<% if (features.includes('userCrud')) { %>
+    { name: 'Users', description: 'Administration des utilisateurs.' },
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+    { name: 'Client', description: 'Espace réservé aux clients.' },
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+    { name: 'Admin', description: 'Espace réservé aux administrateurs.' },
+<% } %>
+  ],
+  paths: {
+    '/health': {
+      get: {
+        tags: ['Health'],
+        summary: 'Vérifie la disponibilité du service',
+        responses: {
+          '200': {
+            description: 'Santé du service',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    status: { type: 'string' },
+                    uptime: { type: 'number' },
+                    timestamp: { type: 'string', format: 'date-time' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+<% if (features.includes('auth')) { %>
+    '/auth/register': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Inscription d\'un nouvel utilisateur',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name', 'email', 'password'],
+                properties: {
+                  name: { type: 'string' },
+                  email: { type: 'string', format: 'email' },
+                  password: { type: 'string', format: 'password' },
+                  role: { $ref: '#/components/schemas/UserRole' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '201': {
+            description: 'Utilisateur créé et connecté',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/AuthTokens' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/login': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Connexion utilisateur',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['email', 'password'],
+                properties: {
+                  email: { type: 'string', format: 'email' },
+                  password: { type: 'string', format: 'password' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Tokens générés',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/AuthTokens' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/refresh': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Renouvelle un access token via refresh token',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['refreshToken'],
+                properties: {
+                  refreshToken: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Nouveaux tokens',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/AuthTokens' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/auth/logout': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Révoque un refresh token actif',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['refreshToken'],
+                properties: {
+                  refreshToken: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '204': { description: 'Refresh token révoqué' }
+        },
+      },
+    },
+    '/me': {
+      get: {
+        tags: ['Profile'],
+        summary: 'Retourne le profil courant',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Profil courant',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+        },
+      },
+    },
+<% } %>
+<% if (features.includes('userCrud')) { %>
+    '/users': {
+      get: {
+        tags: ['Users'],
+        summary: 'Liste paginée des utilisateurs',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Liste des utilisateurs',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    users: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/User' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ['Users'],
+        summary: 'Crée un utilisateur',
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name', 'email', 'password', 'role'],
+                properties: {
+                  name: { type: 'string' },
+                  email: { type: 'string', format: 'email' },
+                  password: { type: 'string', format: 'password' },
+                  role: { $ref: '#/components/schemas/UserRole' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '201': {
+            description: 'Utilisateur créé',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/users/{userId}': {
+      parameters: [
+        {
+          name: 'userId',
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        },
+      ],
+      get: {
+        tags: ['Users'],
+        summary: 'Consulte un utilisateur',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Utilisateur',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+        },
+      },
+      patch: {
+        tags: ['Users'],
+        summary: 'Met à jour un utilisateur',
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  email: { type: 'string', format: 'email' },
+                  password: { type: 'string', format: 'password' },
+                  role: { $ref: '#/components/schemas/UserRole' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Utilisateur mis à jour',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/User' },
+              },
+            },
+          },
+        },
+      },
+      delete: {
+        tags: ['Users'],
+        summary: 'Supprime un utilisateur',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '204': { description: 'Utilisateur supprimé' },
+        },
+      },
+    },
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+    '/client/dashboard': {
+      get: {
+        tags: ['Client'],
+        summary: 'Tableau de bord client',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Données du tableau de bord client',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    message: { type: 'string' },
+                    stats: {
+                      type: 'object',
+                      additionalProperties: { type: 'number' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+    '/admin/dashboard': {
+      get: {
+        tags: ['Admin'],
+        summary: 'Tableau de bord administrateur',
+        security: [{ bearerAuth: [] }],
+        responses: {
+          '200': {
+            description: 'Indicateurs clés administrateur',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    message: { type: 'string' },
+                    metrics: {
+                      type: 'object',
+                      additionalProperties: { type: 'number' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+<% } %>
+  },
+  components: {
+    schemas: {
+      HealthResponse: {
+        type: 'object',
+        properties: {
+          status: { type: 'string' },
+          uptime: { type: 'number' },
+          timestamp: { type: 'string', format: 'date-time' },
+        },
+      },
+      ErrorResponse: {
+        type: 'object',
+        properties: {
+          error: { type: 'string' },
+          message: { type: 'string' },
+          details: { type: 'object' },
+        },
+      },
+<% if (features.includes('auth') || features.includes('userCrud')) { %>
+      UserRole: {
+        type: 'string',
+        enum: ['admin', 'client'],
+      },
+      User: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          email: { type: 'string', format: 'email' },
+          role: { $ref: '#/components/schemas/UserRole' },
+          createdAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' },
+        },
+      },
+<% } %>
+<% if (features.includes('auth')) { %>
+      AuthTokens: {
+        type: 'object',
+        properties: {
+          accessToken: { type: 'string' },
+          refreshToken: { type: 'string' },
+        },
+      },
+<% } %>
+    },
+    securitySchemes: {
+<% if (features.includes('auth')) { %>
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+<% } %>
+    },
+  },
+};

--- a/templates/typescript/base/src/interface/http/docs/swagger.ts.ejs
+++ b/templates/typescript/base/src/interface/http/docs/swagger.ts.ejs
@@ -1,0 +1,7 @@
+import { Express } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { openApiDocument } from './openapi';
+
+export function registerDocs(app: Express) {
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiDocument));
+}

--- a/templates/typescript/base/src/interface/http/middlewares/error-handler.ts.ejs
+++ b/templates/typescript/base/src/interface/http/middlewares/error-handler.ts.ejs
@@ -1,0 +1,39 @@
+import { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
+import { ApplicationError } from '../../../application/errors/application-error';
+import { ValidationError } from '../../../application/errors/validation-error';
+import { logger } from '../../../infrastructure/logging/logger';
+
+export function errorHandler(error: unknown, _request: Request, response: Response, _next: NextFunction) {
+  if (error instanceof ValidationError) {
+    return response.status(error.statusCode).json({
+      error: 'validation_error',
+      message: error.message,
+      details: error.context,
+    });
+  }
+
+  if (error instanceof ZodError) {
+    const validationError = new ValidationError(error);
+    return response.status(validationError.statusCode).json({
+      error: 'validation_error',
+      message: validationError.message,
+      details: validationError.context,
+    });
+  }
+
+  if (error instanceof ApplicationError) {
+    return response.status(error.statusCode).json({
+      error: 'application_error',
+      message: error.message,
+      details: error.context,
+    });
+  }
+
+  logger.error(error, 'Unhandled error');
+
+  return response.status(500).json({
+    error: 'internal_server_error',
+    message: 'An unexpected error occurred.',
+  });
+}

--- a/templates/typescript/base/src/interface/http/middlewares/not-found-handler.ts.ejs
+++ b/templates/typescript/base/src/interface/http/middlewares/not-found-handler.ts.ejs
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+
+export function notFoundHandler(request: Request, response: Response) {
+  return response.status(404).json({
+    error: 'not_found',
+    message: `Cannot ${request.method} ${request.originalUrl}`,
+  });
+}

--- a/templates/typescript/base/src/interface/http/middlewares/validate-request.ts.ejs
+++ b/templates/typescript/base/src/interface/http/middlewares/validate-request.ts.ejs
@@ -1,0 +1,27 @@
+import { NextFunction, Request, Response } from 'express';
+import { AnyZodObject, ZodError } from 'zod';
+import { ValidationError } from '../../../application/errors/validation-error';
+
+export function validateRequest(schema: AnyZodObject) {
+  return (request: Request, _response: Response, next: NextFunction) => {
+    try {
+      const result = schema.parse({
+        body: request.body,
+        params: request.params,
+        query: request.query,
+      });
+
+      request.body = result.body ?? request.body;
+      request.params = result.params ?? request.params;
+      request.query = result.query ?? request.query;
+
+      return next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return next(new ValidationError(error));
+      }
+
+      return next(error);
+    }
+  };
+}

--- a/templates/typescript/base/src/interface/http/routes/index.ts.ejs
+++ b/templates/typescript/base/src/interface/http/routes/index.ts.ejs
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { healthController } from '../controllers/health.controller';
+<% if (features.includes('auth')) { %>
+import { authRoutes } from './auth.routes';
+import { profileController } from '../controllers/profile.controller';
+import { ensureAuthenticated } from '../middlewares/ensure-authenticated';
+<% } %>
+<% if (features.includes('userCrud')) { %>
+import { userRoutes } from './user.routes';
+import { requireRole } from '../middlewares/require-role';
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+import { clientPortalRoutes } from './client.routes';
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+import { adminPortalRoutes } from './admin.routes';
+<% } %>
+
+const routes = Router();
+
+routes.get('/health', (request, response) => healthController.handle(request, response));
+<% if (features.includes('auth')) { %>
+routes.use('/auth', authRoutes);
+routes.get('/me', ensureAuthenticated, (request, response) => profileController.handle(request, response));
+<% } %>
+<% if (features.includes('userCrud')) { %>
+routes.use('/users', ensureAuthenticated, requireRole('admin'), userRoutes);
+<% } %>
+<% if (features.includes('clientPortal')) { %>
+routes.use('/client', ensureAuthenticated, requireRole('client'), clientPortalRoutes);
+<% } %>
+<% if (features.includes('adminPortal')) { %>
+routes.use('/admin', ensureAuthenticated, requireRole('admin'), adminPortalRoutes);
+<% } %>
+
+export { routes };

--- a/templates/typescript/base/src/interface/http/utils/async-handler.ts.ejs
+++ b/templates/typescript/base/src/interface/http/utils/async-handler.ts.ejs
@@ -1,0 +1,7 @@
+import { NextFunction, Request, Response } from 'express';
+
+export function asyncHandler(handler: (request: Request, response: Response, next: NextFunction) => Promise<unknown> | unknown) {
+  return (request: Request, response: Response, next: NextFunction) => {
+    Promise.resolve(handler(request, response, next)).catch(next);
+  };
+}

--- a/templates/typescript/base/src/server.ts.ejs
+++ b/templates/typescript/base/src/server.ts.ejs
@@ -1,0 +1,13 @@
+import { createApp } from './interface/http/app';
+import { env } from './infrastructure/config/env';
+import { logger } from './infrastructure/logging/logger';
+
+async function bootstrap() {
+  const app = createApp();
+
+  app.listen(env.API_PORT, () => {
+    logger.info(`🚀 ${env.APP_NAME} en écoute sur http://localhost:${env.API_PORT}`);
+  });
+}
+
+void bootstrap();

--- a/templates/typescript/base/tests/integration/health.spec.ts.ejs
+++ b/templates/typescript/base/tests/integration/health.spec.ts.ejs
@@ -1,0 +1,13 @@
+import request from 'supertest';
+import { buildTestApp } from '../utils/test-app';
+
+describe('Health check', () => {
+  it('returns application status', async () => {
+    const app = buildTestApp();
+
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ status: 'ok' });
+  });
+});

--- a/templates/typescript/base/tests/setup-env.ts.ejs
+++ b/templates/typescript/base/tests/setup-env.ts.ejs
@@ -1,0 +1,4 @@
+process.env.NODE_ENV = 'test';
+process.env.API_PORT = process.env.API_PORT ?? '3333';
+process.env.CORS_ORIGIN = process.env.CORS_ORIGIN ?? '*';
+process.env.LOG_LEVEL = 'silent';

--- a/templates/typescript/base/tests/utils/test-app.ts.ejs
+++ b/templates/typescript/base/tests/utils/test-app.ts.ejs
@@ -1,0 +1,5 @@
+import { createApp } from '../../src/interface/http/app';
+
+export function buildTestApp() {
+  return createApp();
+}

--- a/templates/typescript/base/tsconfig.json.ejs
+++ b/templates/typescript/base/tsconfig.json.ejs
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "lib": ["ES2021"],
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "tests", "types"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/typescript/features/adminPortal/src/interface/http/controllers/admin-portal.controller.ts.ejs
+++ b/templates/typescript/features/adminPortal/src/interface/http/controllers/admin-portal.controller.ts.ejs
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+
+class AdminPortalController {
+  async dashboard(_request: Request, response: Response) {
+    return response.status(200).json({
+      message: 'Tableau de bord administrateur',
+      metrics: {
+        users: 128,
+        activeClients: 54,
+        monthlyRevenue: 12345,
+      },
+    });
+  }
+}
+
+export const adminPortalController = new AdminPortalController();

--- a/templates/typescript/features/adminPortal/src/interface/http/routes/admin.routes.ts.ejs
+++ b/templates/typescript/features/adminPortal/src/interface/http/routes/admin.routes.ts.ejs
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { adminPortalController } from '../controllers/admin-portal.controller';
+import { asyncHandler } from '../../utils/async-handler';
+
+export const adminPortalRoutes = Router();
+
+adminPortalRoutes.get(
+  '/dashboard',
+  asyncHandler((request, response) => adminPortalController.dashboard(request, response))
+);

--- a/templates/typescript/features/adminPortal/tests/integration/admin-portal.spec.ts.ejs
+++ b/templates/typescript/features/adminPortal/tests/integration/admin-portal.spec.ts.ejs
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import { buildTestApp } from '../../utils/test-app';
+
+describe('Admin portal', () => {
+  it('returns dashboard data for admin users', async () => {
+    const app = buildTestApp();
+
+    const loginResponse = await request(app).post('/auth/login').send({
+      email: 'admin@example.com',
+      password: 'Admin#1234',
+    });
+
+    const { accessToken } = loginResponse.body.tokens;
+
+    const response = await request(app)
+      .get('/admin/dashboard')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('metrics');
+  });
+});

--- a/templates/typescript/features/auth/src/application/errors/authentication-error.ts.ejs
+++ b/templates/typescript/features/auth/src/application/errors/authentication-error.ts.ejs
@@ -1,0 +1,8 @@
+import { ApplicationError } from './application-error';
+
+export class AuthenticationError extends ApplicationError {
+  constructor(message = 'Invalid credentials') {
+    super(message, 401);
+    this.name = 'AuthenticationError';
+  }
+}

--- a/templates/typescript/features/auth/src/application/errors/forbidden-error.ts.ejs
+++ b/templates/typescript/features/auth/src/application/errors/forbidden-error.ts.ejs
@@ -1,0 +1,8 @@
+import { ApplicationError } from './application-error';
+
+export class ForbiddenError extends ApplicationError {
+  constructor(message = 'You are not allowed to perform this action') {
+    super(message, 403);
+    this.name = 'ForbiddenError';
+  }
+}

--- a/templates/typescript/features/auth/src/application/services/password-hasher.ts.ejs
+++ b/templates/typescript/features/auth/src/application/services/password-hasher.ts.ejs
@@ -1,0 +1,4 @@
+export interface PasswordHasher {
+  hash(password: string): Promise<string>;
+  compare(password: string, passwordHash: string): Promise<boolean>;
+}

--- a/templates/typescript/features/auth/src/application/services/token-service.ts.ejs
+++ b/templates/typescript/features/auth/src/application/services/token-service.ts.ejs
@@ -1,0 +1,18 @@
+import { User, UserRole } from '../../domain/entities/user';
+
+export interface AccessPayload {
+  sub: string;
+  role: UserRole;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface TokenService {
+  issueTokens(user: User): Promise<TokenPair>;
+  refreshTokens(refreshToken: string): Promise<TokenPair>;
+  revokeToken(refreshToken: string): Promise<void>;
+  verifyAccessToken(token: string): AccessPayload;
+}

--- a/templates/typescript/features/auth/src/application/use-cases/auth/authenticate-user.usecase.ts.ejs
+++ b/templates/typescript/features/auth/src/application/use-cases/auth/authenticate-user.usecase.ts.ejs
@@ -1,0 +1,41 @@
+import { AuthenticationError } from '../../errors/authentication-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { PasswordHasher } from '../../services/password-hasher';
+import { TokenPair, TokenService } from '../../services/token-service';
+import { User } from '../../../domain/entities/user';
+
+interface AuthenticateUserRequest {
+  email: string;
+  password: string;
+}
+
+interface AuthenticateUserResponse {
+  user: User;
+  tokens: TokenPair;
+}
+
+export class AuthenticateUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly passwordHasher: PasswordHasher,
+    private readonly tokenService: TokenService
+  ) {}
+
+  async execute({ email, password }: AuthenticateUserRequest): Promise<AuthenticateUserResponse> {
+    const user = await this.userRepository.findByEmail(email);
+
+    if (!user) {
+      throw new AuthenticationError();
+    }
+
+    const passwordMatches = await this.passwordHasher.compare(password, user.passwordHash);
+
+    if (!passwordMatches) {
+      throw new AuthenticationError();
+    }
+
+    const tokens = await this.tokenService.issueTokens(user);
+
+    return { user, tokens };
+  }
+}

--- a/templates/typescript/features/auth/src/application/use-cases/auth/get-profile.usecase.ts.ejs
+++ b/templates/typescript/features/auth/src/application/use-cases/auth/get-profile.usecase.ts.ejs
@@ -1,0 +1,21 @@
+import { NotFoundError } from '../../errors/not-found-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { User } from '../../../domain/entities/user';
+
+interface GetProfileRequest {
+  userId: string;
+}
+
+export class GetProfileUseCase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute({ userId }: GetProfileRequest): Promise<User> {
+    const user = await this.userRepository.findById(userId);
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    return user;
+  }
+}

--- a/templates/typescript/features/auth/src/application/use-cases/auth/logout-user.usecase.ts.ejs
+++ b/templates/typescript/features/auth/src/application/use-cases/auth/logout-user.usecase.ts.ejs
@@ -1,0 +1,13 @@
+import { TokenService } from '../../services/token-service';
+
+interface LogoutUserRequest {
+  refreshToken: string;
+}
+
+export class LogoutUserUseCase {
+  constructor(private readonly tokenService: TokenService) {}
+
+  async execute({ refreshToken }: LogoutUserRequest): Promise<void> {
+    await this.tokenService.revokeToken(refreshToken);
+  }
+}

--- a/templates/typescript/features/auth/src/application/use-cases/auth/refresh-token.usecase.ts.ejs
+++ b/templates/typescript/features/auth/src/application/use-cases/auth/refresh-token.usecase.ts.ejs
@@ -1,0 +1,13 @@
+import { TokenPair, TokenService } from '../../services/token-service';
+
+interface RefreshTokenRequest {
+  refreshToken: string;
+}
+
+export class RefreshTokenUseCase {
+  constructor(private readonly tokenService: TokenService) {}
+
+  async execute({ refreshToken }: RefreshTokenRequest): Promise<TokenPair> {
+    return this.tokenService.refreshTokens(refreshToken);
+  }
+}

--- a/templates/typescript/features/auth/src/application/use-cases/auth/register-user.usecase.ts.ejs
+++ b/templates/typescript/features/auth/src/application/use-cases/auth/register-user.usecase.ts.ejs
@@ -1,0 +1,41 @@
+import { ConflictError } from '../../errors/conflict-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { createUser, UserRole } from '../../../domain/entities/user';
+import { PasswordHasher } from '../../services/password-hasher';
+import { TokenService, TokenPair } from '../../services/token-service';
+
+interface RegisterUserRequest {
+  name: string;
+  email: string;
+  password: string;
+  role?: UserRole;
+}
+
+interface RegisterUserResponse {
+  user: ReturnType<typeof createUser>;
+  tokens: TokenPair;
+}
+
+export class RegisterUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly passwordHasher: PasswordHasher,
+    private readonly tokenService: TokenService
+  ) {}
+
+  async execute({ name, email, password, role = 'client' }: RegisterUserRequest): Promise<RegisterUserResponse> {
+    const existingUser = await this.userRepository.findByEmail(email);
+
+    if (existingUser) {
+      throw new ConflictError('Email already registered');
+    }
+
+    const passwordHash = await this.passwordHasher.hash(password);
+    const user = createUser({ name, email, passwordHash, role });
+
+    await this.userRepository.create(user);
+    const tokens = await this.tokenService.issueTokens(user);
+
+    return { user, tokens };
+  }
+}

--- a/templates/typescript/features/auth/src/domain/entities/refresh-token.ts.ejs
+++ b/templates/typescript/features/auth/src/domain/entities/refresh-token.ts.ejs
@@ -1,0 +1,29 @@
+import crypto from 'node:crypto';
+
+export interface RefreshToken {
+  id: string;
+  userId: string;
+  token: string;
+  expiresAt: Date;
+  createdAt: Date;
+  revokedAt?: Date | null;
+}
+
+export interface CreateRefreshTokenInput {
+  id?: string;
+  userId: string;
+  token: string;
+  expiresAt: Date;
+  createdAt?: Date;
+}
+
+export function createRefreshToken(input: CreateRefreshTokenInput): RefreshToken {
+  return {
+    id: input.id ?? crypto.randomUUID(),
+    userId: input.userId,
+    token: input.token,
+    expiresAt: input.expiresAt,
+    createdAt: input.createdAt ?? new Date(),
+    revokedAt: null,
+  };
+}

--- a/templates/typescript/features/auth/src/domain/entities/user.ts.ejs
+++ b/templates/typescript/features/auth/src/domain/entities/user.ts.ejs
@@ -1,0 +1,36 @@
+import crypto from 'node:crypto';
+
+export type UserRole = 'admin' | 'client';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  passwordHash: string;
+  role: UserRole;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateUserInput {
+  id?: string;
+  name: string;
+  email: string;
+  passwordHash: string;
+  role: UserRole;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export function createUser(input: CreateUserInput): User {
+  const now = new Date();
+  return {
+    id: input.id ?? crypto.randomUUID(),
+    name: input.name,
+    email: input.email,
+    passwordHash: input.passwordHash,
+    role: input.role,
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+  };
+}

--- a/templates/typescript/features/auth/src/domain/repositories/refresh-token-repository.ts.ejs
+++ b/templates/typescript/features/auth/src/domain/repositories/refresh-token-repository.ts.ejs
@@ -1,0 +1,8 @@
+import { RefreshToken } from '../entities/refresh-token';
+
+export interface RefreshTokenRepository {
+  create(token: RefreshToken): Promise<RefreshToken>;
+  findByToken(token: string): Promise<RefreshToken | null>;
+  delete(token: string): Promise<void>;
+  deleteByUser(userId: string): Promise<void>;
+}

--- a/templates/typescript/features/auth/src/domain/repositories/user-repository.ts.ejs
+++ b/templates/typescript/features/auth/src/domain/repositories/user-repository.ts.ejs
@@ -1,0 +1,10 @@
+import { User } from '../entities/user';
+
+export interface UserRepository {
+  create(user: User): Promise<User>;
+  update(user: User): Promise<User>;
+  delete(userId: string): Promise<void>;
+  findById(userId: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  list(): Promise<User[]>;
+}

--- a/templates/typescript/features/auth/src/infrastructure/auth/jwt-token.service.ts.ejs
+++ b/templates/typescript/features/auth/src/infrastructure/auth/jwt-token.service.ts.ejs
@@ -1,0 +1,105 @@
+import crypto from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { env } from '../../../infrastructure/config/env';
+import { AuthenticationError } from '../../application/errors/authentication-error';
+import { RefreshTokenRepository } from '../../domain/repositories/refresh-token-repository';
+import { createRefreshToken } from '../../domain/entities/refresh-token';
+import { User, UserRole } from '../../domain/entities/user';
+import { AccessPayload, TokenPair, TokenService } from '../../application/services/token-service';
+import { UserRepository } from '../../domain/repositories/user-repository';
+
+function parseDuration(duration: string): number {
+  const match = duration.match(/^(\d+)([smhd])$/i);
+
+  if (!match) {
+    throw new Error(`Invalid duration format: ${duration}`);
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const unitMultipliers: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+
+  return value * unitMultipliers[unit];
+}
+
+function hashRefreshToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+export class JwtTokenService implements TokenService {
+  private readonly accessTokenTtlMs = parseDuration(env.ACCESS_TOKEN_TTL);
+  private readonly refreshTokenTtlMs = parseDuration(env.REFRESH_TOKEN_TTL);
+
+  constructor(
+    private readonly refreshTokenRepository: RefreshTokenRepository,
+    private readonly userRepository: UserRepository
+  ) {}
+
+  async issueTokens(user: User): Promise<TokenPair> {
+    const accessToken = this.generateAccessToken(user.id, user.role);
+    const refreshTokenValue = crypto.randomUUID();
+
+    const refreshToken = createRefreshToken({
+      userId: user.id,
+      token: hashRefreshToken(refreshTokenValue),
+      expiresAt: new Date(Date.now() + this.refreshTokenTtlMs),
+    });
+
+    await this.refreshTokenRepository.create(refreshToken);
+
+    return { accessToken, refreshToken: refreshTokenValue };
+  }
+
+  async refreshTokens(refreshToken: string): Promise<TokenPair> {
+    const hashedToken = hashRefreshToken(refreshToken);
+    const storedToken = await this.refreshTokenRepository.findByToken(hashedToken);
+
+    if (!storedToken) {
+      throw new AuthenticationError('Refresh token invalid');
+    }
+
+    if (storedToken.expiresAt.getTime() < Date.now()) {
+      await this.refreshTokenRepository.delete(hashedToken);
+      throw new AuthenticationError('Refresh token expired');
+    }
+
+    const user = await this.userRepository.findById(storedToken.userId);
+
+    if (!user) {
+      await this.refreshTokenRepository.delete(hashedToken);
+      throw new AuthenticationError('User not found');
+    }
+
+    await this.refreshTokenRepository.delete(hashedToken);
+
+    return this.issueTokens(user);
+  }
+
+  async revokeToken(refreshToken: string): Promise<void> {
+    await this.refreshTokenRepository.delete(hashRefreshToken(refreshToken));
+  }
+
+  verifyAccessToken(token: string): AccessPayload {
+    const payload = jwt.verify(token, env.JWT_SECRET) as jwt.JwtPayload;
+
+    if (!payload.sub || !payload.role) {
+      throw new AuthenticationError('Invalid access token');
+    }
+
+    return {
+      sub: String(payload.sub),
+      role: payload.role as UserRole,
+    };
+  }
+
+  private generateAccessToken(userId: string, role: UserRole): string {
+    return jwt.sign({ sub: userId, role }, env.JWT_SECRET, {
+      expiresIn: Math.floor(this.accessTokenTtlMs / 1000),
+    });
+  }
+}

--- a/templates/typescript/features/auth/src/infrastructure/hashing/bcrypt-password-hasher.ts.ejs
+++ b/templates/typescript/features/auth/src/infrastructure/hashing/bcrypt-password-hasher.ts.ejs
@@ -1,0 +1,14 @@
+import bcrypt from 'bcryptjs';
+import { PasswordHasher } from '../../application/services/password-hasher';
+
+export class BcryptPasswordHasher implements PasswordHasher {
+  private readonly rounds = 10;
+
+  async hash(password: string): Promise<string> {
+    return bcrypt.hash(password, this.rounds);
+  }
+
+  async compare(password: string, passwordHash: string): Promise<boolean> {
+    return bcrypt.compare(password, passwordHash);
+  }
+}

--- a/templates/typescript/features/auth/src/infrastructure/persistence/in-memory/in-memory-refresh-token.repository.ts.ejs
+++ b/templates/typescript/features/auth/src/infrastructure/persistence/in-memory/in-memory-refresh-token.repository.ts.ejs
@@ -1,0 +1,24 @@
+import { RefreshToken } from '../../../domain/entities/refresh-token';
+import { RefreshTokenRepository } from '../../../domain/repositories/refresh-token-repository';
+
+export class InMemoryRefreshTokenRepository implements RefreshTokenRepository {
+  private tokens: RefreshToken[] = [];
+
+  async create(token: RefreshToken): Promise<RefreshToken> {
+    this.tokens.push({ ...token });
+    return token;
+  }
+
+  async findByToken(token: string): Promise<RefreshToken | null> {
+    const refreshToken = this.tokens.find((item) => item.token === token);
+    return refreshToken ? { ...refreshToken } : null;
+  }
+
+  async delete(token: string): Promise<void> {
+    this.tokens = this.tokens.filter((item) => item.token !== token);
+  }
+
+  async deleteByUser(userId: string): Promise<void> {
+    this.tokens = this.tokens.filter((item) => item.userId !== userId);
+  }
+}

--- a/templates/typescript/features/auth/src/infrastructure/persistence/in-memory/in-memory-user.repository.ts.ejs
+++ b/templates/typescript/features/auth/src/infrastructure/persistence/in-memory/in-memory-user.repository.ts.ejs
@@ -1,0 +1,44 @@
+import { User } from '../../../domain/entities/user';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+
+export class InMemoryUserRepository implements UserRepository {
+  private users: User[] = [];
+
+  constructor(seedUsers: User[] = []) {
+    this.users = seedUsers.map((user) => ({ ...user }));
+  }
+
+  async create(user: User): Promise<User> {
+    this.users.push({ ...user });
+    return user;
+  }
+
+  async update(user: User): Promise<User> {
+    const index = this.users.findIndex((item) => item.id === user.id);
+
+    if (index === -1) {
+      throw new Error('User not found');
+    }
+
+    this.users[index] = { ...user, updatedAt: new Date() };
+    return this.users[index];
+  }
+
+  async delete(userId: string): Promise<void> {
+    this.users = this.users.filter((user) => user.id !== userId);
+  }
+
+  async findById(userId: string): Promise<User | null> {
+    const user = this.users.find((item) => item.id === userId);
+    return user ? { ...user } : null;
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    const user = this.users.find((item) => item.email.toLowerCase() === email.toLowerCase());
+    return user ? { ...user } : null;
+  }
+
+  async list(): Promise<User[]> {
+    return this.users.map((user) => ({ ...user }));
+  }
+}

--- a/templates/typescript/features/auth/src/interface/http/controllers/auth.controller.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/controllers/auth.controller.ts.ejs
@@ -1,0 +1,50 @@
+import { Request, Response } from 'express';
+import {
+  makeAuthenticateUserUseCase,
+  makeRefreshTokenUseCase,
+  makeRegisterUserUseCase,
+  makeLogoutUserUseCase,
+} from '../../../infrastructure/container';
+import { userPresenter } from '../presenters/user.presenter';
+
+class AuthController {
+  async register(request: Request, response: Response) {
+    const { name, email, password, role } = request.body;
+    const registerUser = makeRegisterUserUseCase();
+    const result = await registerUser.execute({ name, email, password, role });
+
+    return response.status(201).json({
+      user: userPresenter.toHttp(result.user),
+      tokens: result.tokens,
+    });
+  }
+
+  async login(request: Request, response: Response) {
+    const { email, password } = request.body;
+    const authenticateUser = makeAuthenticateUserUseCase();
+    const result = await authenticateUser.execute({ email, password });
+
+    return response.status(200).json({
+      user: userPresenter.toHttp(result.user),
+      tokens: result.tokens,
+    });
+  }
+
+  async refresh(request: Request, response: Response) {
+    const { refreshToken } = request.body;
+    const refreshTokenUseCase = makeRefreshTokenUseCase();
+    const tokens = await refreshTokenUseCase.execute({ refreshToken });
+
+    return response.status(200).json(tokens);
+  }
+
+  async logout(request: Request, response: Response) {
+    const { refreshToken } = request.body;
+    const logoutUseCase = makeLogoutUserUseCase();
+    await logoutUseCase.execute({ refreshToken });
+
+    return response.status(204).send();
+  }
+}
+
+export const authController = new AuthController();

--- a/templates/typescript/features/auth/src/interface/http/controllers/profile.controller.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/controllers/profile.controller.ts.ejs
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { makeGetProfileUseCase } from '../../../infrastructure/container';
+import { userPresenter } from '../presenters/user.presenter';
+
+class ProfileController {
+  async handle(request: Request, response: Response) {
+    const currentUser = request.user;
+
+    const getProfile = makeGetProfileUseCase();
+    const user = await getProfile.execute({ userId: currentUser.id });
+
+    return response.status(200).json(userPresenter.toHttp(user));
+  }
+}
+
+export const profileController = new ProfileController();

--- a/templates/typescript/features/auth/src/interface/http/middlewares/ensure-authenticated.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/middlewares/ensure-authenticated.ts.ejs
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from 'express';
+import { AuthenticationError } from '../../../application/errors/authentication-error';
+import { resolveTokenService, resolveUserRepository } from '../../../infrastructure/container';
+
+export async function ensureAuthenticated(request: Request, _response: Response, next: NextFunction) {
+  try {
+    const authorization = request.headers.authorization;
+
+    if (!authorization) {
+      throw new AuthenticationError('Authorization header missing');
+    }
+
+    const [, token] = authorization.split(' ');
+
+    if (!token) {
+      throw new AuthenticationError('Invalid authorization header');
+    }
+
+    const payload = resolveTokenService().verifyAccessToken(token);
+    const user = await resolveUserRepository().findById(payload.sub);
+
+    if (!user) {
+      throw new AuthenticationError('User not found');
+    }
+
+    request.user = { id: user.id, role: user.role };
+
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+}

--- a/templates/typescript/features/auth/src/interface/http/middlewares/require-role.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/middlewares/require-role.ts.ejs
@@ -1,0 +1,15 @@
+import { NextFunction, Request, Response } from 'express';
+import { ForbiddenError } from '../../../application/errors/forbidden-error';
+import { UserRole } from '../../../domain/entities/user';
+
+export function requireRole(...allowedRoles: UserRole[]) {
+  return (request: Request, _response: Response, next: NextFunction) => {
+    const user = request.user;
+
+    if (!allowedRoles.includes(user.role)) {
+      return next(new ForbiddenError());
+    }
+
+    return next();
+  };
+}

--- a/templates/typescript/features/auth/src/interface/http/presenters/user.presenter.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/presenters/user.presenter.ts.ejs
@@ -1,0 +1,14 @@
+import { User } from '../../../domain/entities/user';
+
+export const userPresenter = {
+  toHttp(user: User) {
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      createdAt: user.createdAt.toISOString(),
+      updatedAt: user.updatedAt.toISOString(),
+    };
+  },
+};

--- a/templates/typescript/features/auth/src/interface/http/routes/auth.routes.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/routes/auth.routes.ts.ejs
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { authController } from '../controllers/auth.controller';
+import { asyncHandler } from '../../utils/async-handler';
+import { validateRequest } from '../middlewares/validate-request';
+import {
+  loginSchema,
+  refreshSchema,
+  registerSchema,
+  logoutSchema,
+} from '../validators/auth.validators';
+
+export const authRoutes = Router();
+
+authRoutes.post(
+  '/register',
+  validateRequest(registerSchema),
+  asyncHandler((request, response) => authController.register(request, response))
+);
+
+authRoutes.post(
+  '/login',
+  validateRequest(loginSchema),
+  asyncHandler((request, response) => authController.login(request, response))
+);
+
+authRoutes.post(
+  '/refresh',
+  validateRequest(refreshSchema),
+  asyncHandler((request, response) => authController.refresh(request, response))
+);
+
+authRoutes.post(
+  '/logout',
+  validateRequest(logoutSchema),
+  asyncHandler((request, response) => authController.logout(request, response))
+);

--- a/templates/typescript/features/auth/src/interface/http/validators/auth.validators.ts.ejs
+++ b/templates/typescript/features/auth/src/interface/http/validators/auth.validators.ts.ejs
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+const userRoleSchema = z.enum(['admin', 'client']);
+
+export const registerSchema = z.object({
+  body: z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    password: z.string().min(8),
+    role: userRoleSchema.optional(),
+  }),
+});
+
+export const loginSchema = z.object({
+  body: z.object({
+    email: z.string().email(),
+    password: z.string().min(8),
+  }),
+});
+
+export const refreshSchema = z.object({
+  body: z.object({
+    refreshToken: z.string().min(10),
+  }),
+});
+
+export const logoutSchema = refreshSchema;

--- a/templates/typescript/features/auth/src/types/express/index.d.ts.ejs
+++ b/templates/typescript/features/auth/src/types/express/index.d.ts.ejs
@@ -1,0 +1,16 @@
+import { UserRole } from '../../domain/entities/user';
+
+declare global {
+  namespace Express {
+    interface AuthenticatedUser {
+      id: string;
+      role: UserRole;
+    }
+
+    interface Request {
+      user: AuthenticatedUser;
+    }
+  }
+}
+
+export {};

--- a/templates/typescript/features/auth/tests/integration/authentication.spec.ts.ejs
+++ b/templates/typescript/features/auth/tests/integration/authentication.spec.ts.ejs
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import { buildTestApp } from '../../utils/test-app';
+
+describe('Authentication flows', () => {
+  it('registers a new user and returns tokens', async () => {
+    const app = buildTestApp();
+
+    const response = await request(app).post('/auth/register').send({
+      name: 'Test User',
+      email: 'test@example.com',
+      password: 'Password#123',
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.tokens).toEqual(
+      expect.objectContaining({ accessToken: expect.any(String), refreshToken: expect.any(String) })
+    );
+  });
+
+  it('authenticates an existing user and returns profile data', async () => {
+    const app = buildTestApp();
+
+    const loginResponse = await request(app).post('/auth/login').send({
+      email: 'admin@example.com',
+      password: 'Admin#1234',
+    });
+
+    expect(loginResponse.status).toBe(200);
+    const { accessToken, refreshToken } = loginResponse.body.tokens;
+
+    const profileResponse = await request(app)
+      .get('/me')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(profileResponse.status).toBe(200);
+    expect(profileResponse.body).toMatchObject({ email: 'admin@example.com', role: 'admin' });
+
+    const refreshResponse = await request(app).post('/auth/refresh').send({ refreshToken });
+    expect(refreshResponse.status).toBe(200);
+    expect(refreshResponse.body).toEqual(
+      expect.objectContaining({ accessToken: expect.any(String), refreshToken: expect.any(String) })
+    );
+  });
+});

--- a/templates/typescript/features/clientPortal/src/interface/http/controllers/client-portal.controller.ts.ejs
+++ b/templates/typescript/features/clientPortal/src/interface/http/controllers/client-portal.controller.ts.ejs
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+
+class ClientPortalController {
+  async dashboard(request: Request, response: Response) {
+    return response.status(200).json({
+      message: `Bienvenue dans votre espace client, ${request.user.id}!`,
+      stats: {
+        activeSubscriptions: 2,
+        pendingInvoices: 1,
+        lastLoginAt: new Date().toISOString(),
+      },
+    });
+  }
+}
+
+export const clientPortalController = new ClientPortalController();

--- a/templates/typescript/features/clientPortal/src/interface/http/routes/client.routes.ts.ejs
+++ b/templates/typescript/features/clientPortal/src/interface/http/routes/client.routes.ts.ejs
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { clientPortalController } from '../controllers/client-portal.controller';
+import { asyncHandler } from '../../utils/async-handler';
+
+export const clientPortalRoutes = Router();
+
+clientPortalRoutes.get(
+  '/dashboard',
+  asyncHandler((request, response) => clientPortalController.dashboard(request, response))
+);

--- a/templates/typescript/features/clientPortal/tests/integration/client-portal.spec.ts.ejs
+++ b/templates/typescript/features/clientPortal/tests/integration/client-portal.spec.ts.ejs
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import { buildTestApp } from '../../utils/test-app';
+
+describe('Client portal', () => {
+  it('returns dashboard data for client users', async () => {
+    const app = buildTestApp();
+
+    const loginResponse = await request(app).post('/auth/login').send({
+      email: 'client@example.com',
+      password: 'Client#1234',
+    });
+
+    const { accessToken } = loginResponse.body.tokens;
+
+    const response = await request(app)
+      .get('/client/dashboard')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('stats');
+  });
+});

--- a/templates/typescript/features/userCrud/src/application/use-cases/users/create-user.usecase.ts.ejs
+++ b/templates/typescript/features/userCrud/src/application/use-cases/users/create-user.usecase.ts.ejs
@@ -1,0 +1,32 @@
+import { ConflictError } from '../../errors/conflict-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { PasswordHasher } from '../../services/password-hasher';
+import { createUser, User, UserRole } from '../../../domain/entities/user';
+
+interface CreateUserRequest {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export class CreateUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly passwordHasher: PasswordHasher
+  ) {}
+
+  async execute({ name, email, password, role }: CreateUserRequest): Promise<User> {
+    const existing = await this.userRepository.findByEmail(email);
+
+    if (existing) {
+      throw new ConflictError('Email already registered');
+    }
+
+    const passwordHash = await this.passwordHasher.hash(password);
+    const user = createUser({ name, email, passwordHash, role });
+
+    await this.userRepository.create(user);
+    return user;
+  }
+}

--- a/templates/typescript/features/userCrud/src/application/use-cases/users/delete-user.usecase.ts.ejs
+++ b/templates/typescript/features/userCrud/src/application/use-cases/users/delete-user.usecase.ts.ejs
@@ -1,0 +1,25 @@
+import { NotFoundError } from '../../errors/not-found-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { RefreshTokenRepository } from '../../../domain/repositories/refresh-token-repository';
+
+interface DeleteUserRequest {
+  userId: string;
+}
+
+export class DeleteUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly refreshTokenRepository: RefreshTokenRepository
+  ) {}
+
+  async execute({ userId }: DeleteUserRequest): Promise<void> {
+    const user = await this.userRepository.findById(userId);
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    await this.refreshTokenRepository.deleteByUser(userId);
+    await this.userRepository.delete(userId);
+  }
+}

--- a/templates/typescript/features/userCrud/src/application/use-cases/users/get-user.usecase.ts.ejs
+++ b/templates/typescript/features/userCrud/src/application/use-cases/users/get-user.usecase.ts.ejs
@@ -1,0 +1,21 @@
+import { NotFoundError } from '../../errors/not-found-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { User } from '../../../domain/entities/user';
+
+interface GetUserRequest {
+  userId: string;
+}
+
+export class GetUserUseCase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute({ userId }: GetUserRequest): Promise<User> {
+    const user = await this.userRepository.findById(userId);
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    return user;
+  }
+}

--- a/templates/typescript/features/userCrud/src/application/use-cases/users/list-users.usecase.ts.ejs
+++ b/templates/typescript/features/userCrud/src/application/use-cases/users/list-users.usecase.ts.ejs
@@ -1,0 +1,11 @@
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { User } from '../../../domain/entities/user';
+
+export class ListUsersUseCase {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(): Promise<{ users: User[] }> {
+    const users = await this.userRepository.list();
+    return { users };
+  }
+}

--- a/templates/typescript/features/userCrud/src/application/use-cases/users/update-user.usecase.ts.ejs
+++ b/templates/typescript/features/userCrud/src/application/use-cases/users/update-user.usecase.ts.ejs
@@ -1,0 +1,54 @@
+import { ConflictError } from '../../errors/conflict-error';
+import { NotFoundError } from '../../errors/not-found-error';
+import { UserRepository } from '../../../domain/repositories/user-repository';
+import { PasswordHasher } from '../../services/password-hasher';
+import { UserRole } from '../../../domain/entities/user';
+
+interface UpdateUserRequest {
+  userId: string;
+  name?: string;
+  email?: string;
+  password?: string;
+  role?: UserRole;
+}
+
+export class UpdateUserUseCase {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly passwordHasher: PasswordHasher
+  ) {}
+
+  async execute({ userId, name, email, password, role }: UpdateUserRequest) {
+    const user = await this.userRepository.findById(userId);
+
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
+
+    if (email && email !== user.email) {
+      const exists = await this.userRepository.findByEmail(email);
+      if (exists && exists.id !== userId) {
+        throw new ConflictError('Email already registered');
+      }
+      user.email = email;
+    }
+
+    if (name) {
+      user.name = name;
+    }
+
+    if (role) {
+      user.role = role;
+    }
+
+    if (password) {
+      user.passwordHash = await this.passwordHasher.hash(password);
+    }
+
+    user.updatedAt = new Date();
+
+    await this.userRepository.update(user);
+
+    return user;
+  }
+}

--- a/templates/typescript/features/userCrud/src/interface/http/controllers/user.controller.ts.ejs
+++ b/templates/typescript/features/userCrud/src/interface/http/controllers/user.controller.ts.ejs
@@ -1,0 +1,58 @@
+import { Request, Response } from 'express';
+import {
+  makeCreateUserUseCase,
+  makeDeleteUserUseCase,
+  makeGetUserUseCase,
+  makeListUsersUseCase,
+  makeUpdateUserUseCase,
+} from '../../../infrastructure/container';
+import { userPresenter } from '../presenters/user.presenter';
+
+class UserController {
+  async index(_request: Request, response: Response) {
+    const listUsers = makeListUsersUseCase();
+    const result = await listUsers.execute();
+
+    return response.status(200).json({
+      users: result.users.map((user) => userPresenter.toHttp(user)),
+    });
+  }
+
+  async show(request: Request, response: Response) {
+    const getUser = makeGetUserUseCase();
+    const user = await getUser.execute({ userId: request.params.userId });
+
+    return response.status(200).json(userPresenter.toHttp(user));
+  }
+
+  async create(request: Request, response: Response) {
+    const { name, email, password, role } = request.body;
+    const createUser = makeCreateUserUseCase();
+    const user = await createUser.execute({ name, email, password, role });
+
+    return response.status(201).json(userPresenter.toHttp(user));
+  }
+
+  async update(request: Request, response: Response) {
+    const { name, email, password, role } = request.body;
+    const updateUser = makeUpdateUserUseCase();
+    const user = await updateUser.execute({
+      userId: request.params.userId,
+      name,
+      email,
+      password,
+      role,
+    });
+
+    return response.status(200).json(userPresenter.toHttp(user));
+  }
+
+  async delete(request: Request, response: Response) {
+    const deleteUser = makeDeleteUserUseCase();
+    await deleteUser.execute({ userId: request.params.userId });
+
+    return response.status(204).send();
+  }
+}
+
+export const userController = new UserController();

--- a/templates/typescript/features/userCrud/src/interface/http/routes/user.routes.ts.ejs
+++ b/templates/typescript/features/userCrud/src/interface/http/routes/user.routes.ts.ejs
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { userController } from '../controllers/user.controller';
+import { asyncHandler } from '../../utils/async-handler';
+import { validateRequest } from '../middlewares/validate-request';
+import {
+  createUserSchema,
+  getUserSchema,
+  updateUserSchema,
+  deleteUserSchema,
+} from '../validators/user.validators';
+
+export const userRoutes = Router();
+
+userRoutes.get('/', asyncHandler((request, response) => userController.index(request, response)));
+
+userRoutes.post(
+  '/',
+  validateRequest(createUserSchema),
+  asyncHandler((request, response) => userController.create(request, response))
+);
+
+userRoutes.get(
+  '/:userId',
+  validateRequest(getUserSchema),
+  asyncHandler((request, response) => userController.show(request, response))
+);
+
+userRoutes.patch(
+  '/:userId',
+  validateRequest(updateUserSchema),
+  asyncHandler((request, response) => userController.update(request, response))
+);
+
+userRoutes.delete(
+  '/:userId',
+  validateRequest(deleteUserSchema),
+  asyncHandler((request, response) => userController.delete(request, response))
+);

--- a/templates/typescript/features/userCrud/src/interface/http/validators/user.validators.ts.ejs
+++ b/templates/typescript/features/userCrud/src/interface/http/validators/user.validators.ts.ejs
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+const userRoleSchema = z.enum(['admin', 'client']);
+const userIdParams = z.object({
+  params: z.object({
+    userId: z.string().uuid(),
+  }),
+});
+
+export const createUserSchema = z.object({
+  body: z.object({
+    name: z.string().min(1),
+    email: z.string().email(),
+    password: z.string().min(8),
+    role: userRoleSchema,
+  }),
+});
+
+export const updateUserSchema = z.object({
+  params: userIdParams.shape.params,
+  body: z
+    .object({
+      name: z.string().min(1).optional(),
+      email: z.string().email().optional(),
+      password: z.string().min(8).optional(),
+      role: userRoleSchema.optional(),
+    })
+    .refine((data) => Object.keys(data).length > 0, {
+      message: 'At least one field must be provided',
+    }),
+});
+
+export const getUserSchema = userIdParams;
+export const deleteUserSchema = userIdParams;

--- a/templates/typescript/features/userCrud/tests/integration/users.spec.ts.ejs
+++ b/templates/typescript/features/userCrud/tests/integration/users.spec.ts.ejs
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import { buildTestApp } from '../../utils/test-app';
+
+describe('User administration', () => {
+  async function authenticateAdmin() {
+    const app = buildTestApp();
+    const response = await request(app).post('/auth/login').send({
+      email: 'admin@example.com',
+      password: 'Admin#1234',
+    });
+
+    return { app, token: response.body.tokens.accessToken };
+  }
+
+  it('allows an admin to list and create users', async () => {
+    const { app, token } = await authenticateAdmin();
+
+    const createResponse = await request(app)
+      .post('/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'New Client',
+        email: 'new-client@example.com',
+        password: 'Client#1234',
+        role: 'client',
+      });
+
+    expect(createResponse.status).toBe(201);
+
+    const listResponse = await request(app)
+      .get('/users')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(listResponse.status).toBe(200);
+    expect(Array.isArray(listResponse.body.users)).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- replace the previous in-repo API with a CLI entrypoint that gathers options, resolves feature dependencies and drives template generation safely
- add TypeScript and JavaScript template sources with base configs, docs, tests and optional modules (auth, user CRUD, client/admin portals) backed by in-memory adapters and synchronous bcrypt seeding
- document the new generator workflow and expose the binary via package metadata
