### PR TITLE
feat: enhance status diagnostics and coverage

### DIFF
--- a/src/cli/generators/javascript-generator.ts
+++ b/src/cli/generators/javascript-generator.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs from 'fs-extra';
 import ts from 'typescript';
 import { BaseTemplateGenerator, GenerateProjectOptions, TemplateDependencies, TemplateContext } from './base-generator';
-import { FeatureKey, Language } from './types';
+import { DataProviderKey, FeatureKey, Language } from './types';
 
 const templateRoot = path.resolve(__dirname, '../../..', 'templates', 'javascript');
 
@@ -20,7 +20,11 @@ export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
     return fs.existsSync(featurePath) ? featurePath : undefined;
   }
 
-  protected buildDependencies(_language: Language, features: FeatureKey[]): TemplateDependencies {
+  protected buildDependencies(
+    _language: Language,
+    features: FeatureKey[],
+    dataProviders: DataProviderKey[]
+  ): TemplateDependencies {
     const dependencies = [
       { name: 'cors', version: '^2.8.5' },
       { name: 'dotenv', version: '^16.4.1' },
@@ -48,6 +52,29 @@ export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
       dependencies.push({ name: 'jsonwebtoken', version: '^9.0.2' });
     }
 
+    for (const provider of dataProviders) {
+      if (provider === 'postgresql') {
+        dependencies.push({ name: 'pg', version: '^8.11.3' });
+      }
+
+      if (provider === 'mysql') {
+        dependencies.push({ name: 'mysql2', version: '^3.9.7' });
+      }
+
+      if (provider === 'sqlite') {
+        dependencies.push({ name: 'better-sqlite3', version: '^9.4.5' });
+      }
+
+      if (provider === 'prisma') {
+        dependencies.push({ name: '@prisma/client', version: '^5.10.2' });
+        devDependencies.push({ name: 'prisma', version: '^5.10.2' });
+      }
+
+      if (provider === 's3') {
+        dependencies.push({ name: '@aws-sdk/client-s3', version: '^3.550.0' });
+      }
+    }
+
     const scripts: Record<string, string> = {
       dev: 'nodemon src/server.js',
       start: 'node src/server.js',
@@ -56,7 +83,14 @@ export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
       'test:watch': 'jest --watch',
       lint: 'eslint "src/**/*.js"',
       format: 'prettier --write "src/**/*.js"',
+      api: 'node scripts/api-cli.js',
     };
+
+    if (dataProviders.includes('prisma')) {
+      scripts['prisma:generate'] = 'prisma generate';
+      scripts['prisma:migrate'] = 'prisma migrate dev';
+      scripts['prisma:studio'] = 'prisma studio';
+    }
 
     return {
       dependencies,
@@ -72,6 +106,9 @@ export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
       hasUserCrud: options.features.includes('userCrud'),
       hasClientPortal: options.features.includes('clientPortal'),
       hasAdminPortal: options.features.includes('adminPortal'),
+      hasDatabaseProviders: options.dataProviders.some((provider) => provider === 'postgresql' || provider === 'mysql' || provider === 'sqlite'),
+      hasPrisma: options.dataProviders.includes('prisma'),
+      hasObjectStorage: options.dataProviders.includes('s3'),
     };
   }
 
@@ -105,10 +142,14 @@ export class JavaScriptTemplateGenerator extends BaseTemplateGenerator {
     const baseSrc = path.join(typescriptRoot, 'base', 'src');
     const baseTests = path.join(typescriptRoot, 'base', 'tests');
     const baseDocs = path.join(typescriptRoot, 'base', 'docs');
+    const baseScripts = path.join(typescriptRoot, 'base', 'scripts');
 
     await this.copyTemplateDirectory(baseSrc, path.join(options.targetDirectory, 'src'), context);
     await this.copyTemplateDirectory(baseTests, path.join(options.targetDirectory, 'tests'), context);
     await this.copyTemplateDirectory(baseDocs, path.join(options.targetDirectory, 'docs'), context);
+    if (fs.existsSync(baseScripts)) {
+      await this.copyTemplateDirectory(baseScripts, path.join(options.targetDirectory, 'scripts'), context);
+    }
 
     for (const feature of options.features) {
       const featureDir = path.join(typescriptRoot, 'features', feature);

--- a/src/cli/generators/types.ts
+++ b/src/cli/generators/types.ts
@@ -6,12 +6,26 @@ export type FeatureKey =
   | 'clientPortal'
   | 'adminPortal';
 
+export type DataProviderKey = 'postgresql' | 'mysql' | 'sqlite' | 'prisma' | 's3';
+
 export interface FeatureDefinition {
   key: FeatureKey;
   name: string;
   description: string;
   summary: string;
   dependencies?: FeatureKey[];
+}
+
+export type DataProviderKind = 'database' | 'orm' | 'storage';
+
+export interface DataProviderDefinition {
+  key: DataProviderKey;
+  name: string;
+  description: string;
+  summary: string;
+  kind: DataProviderKind;
+  defaultStatus: 'ok' | 'warning' | 'critical' | 'skipped';
+  statusDescription: string;
 }
 
 export const featureCatalog: FeatureDefinition[] = [
@@ -51,6 +65,56 @@ export const featureCatalog: FeatureDefinition[] = [
 ];
 
 export const featureCatalogMap = new Map(featureCatalog.map((feature) => [feature.key, feature]));
+
+export const dataProviderCatalog: DataProviderDefinition[] = [
+  {
+    key: 'postgresql',
+    name: 'PostgreSQL',
+    description: 'Base de données relationnelle robuste et extensible, idéale pour les API critiques.',
+    summary: 'Prêt pour PostgreSQL : variables d\'environnement et dépendances du client `pg`.',
+    kind: 'database',
+    defaultStatus: 'warning',
+    statusDescription: 'Client PostgreSQL installé. Configurez DATABASE_URL pour activer la connexion.',
+  },
+  {
+    key: 'mysql',
+    name: 'MySQL',
+    description: 'Base relationnelle populaire avec un vaste écosystème d\'outils et d\'hébergements.',
+    summary: 'Support MySQL prêt avec le driver `mysql2`.',
+    kind: 'database',
+    defaultStatus: 'warning',
+    statusDescription: 'Client MySQL installé. Définissez MYSQL_DSN pour connecter votre instance.',
+  },
+  {
+    key: 'sqlite',
+    name: 'SQLite',
+    description: 'Base relationnelle légère stockée sur le disque, parfaite pour les tests ou prototypes.',
+    summary: 'Driver SQLite prêt à être câblé dans vos adapters.',
+    kind: 'database',
+    defaultStatus: 'warning',
+    statusDescription: 'Bibliothèque SQLite installée. Fournissez le chemin du fichier SQLITEDB pour l\'utiliser.',
+  },
+  {
+    key: 'prisma',
+    name: 'Prisma ORM',
+    description: 'ORM moderne permettant de modéliser votre schéma et générer un client typesafe.',
+    summary: 'Prisma initialisé (CLI + client) avec scripts de migration.',
+    kind: 'orm',
+    defaultStatus: 'warning',
+    statusDescription: 'Prisma installé. Initialisez votre schéma avec `npx prisma init`.',
+  },
+  {
+    key: 's3',
+    name: 'Stockage objet S3',
+    description: 'Intégration prête avec AWS S3 (compatible MinIO) pour gérer vos fichiers.',
+    summary: 'Client AWS S3 disponible. Configurez les identifiants pour activer l\'adapter.',
+    kind: 'storage',
+    defaultStatus: 'warning',
+    statusDescription: 'Client S3 en attente de configuration (AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).',
+  },
+];
+
+export const dataProviderCatalogMap = new Map(dataProviderCatalog.map((provider) => [provider.key, provider]));
 
 export function resolveFeatureDependencies(selected: FeatureKey[]): FeatureKey[] {
   const resolved = new Set<FeatureKey>();

--- a/src/cli/prompts/prompts.ts
+++ b/src/cli/prompts/prompts.ts
@@ -1,34 +1,70 @@
 import inquirer from 'inquirer';
+import path from 'node:path';
 import {
+  DataProviderKey,
   FeatureKey,
   Language,
+  dataProviderCatalog,
+  dataProviderCatalogMap,
   featureCatalog,
   featureCatalogMap,
   resolveFeatureDependencies,
 } from '../generators/types';
 
 export interface PromptAnswers {
+  targetDirectory: string;
   projectName: string;
   language: Language;
   features: FeatureKey[];
   packageManager: 'npm' | 'pnpm' | 'yarn';
+  dataProviders: DataProviderKey[];
 }
 
 export interface PromptOptions {
+  targetDirectory?: string;
   projectName?: string;
   language?: Language;
   features?: FeatureKey[];
   packageManager?: 'npm' | 'pnpm' | 'yarn';
+  dataProviders?: DataProviderKey[];
 }
 
 export async function promptForMissingOptions(options: PromptOptions): Promise<PromptAnswers> {
   const questions: inquirer.QuestionCollection[] = [];
+
+  if (!options.targetDirectory) {
+    questions.push({
+      type: 'input',
+      name: 'targetDirectory',
+      message: 'Dans quel dossier souhaitez-vous générer le template ? (il sera créé si besoin)',
+      default: './mon-api',
+      filter: (input: string) => input.trim() || './mon-api',
+      validate: (input: string) => {
+        const value = input.trim();
+        if (!value) {
+          return 'Indiquez un chemin de dossier valide.';
+        }
+        if (value === '.' || value === './' || value === './.' || value === '..') {
+          return 'Choisissez un dossier dédié (évitez d\'écraser le projet courant).';
+        }
+        return true;
+      },
+    });
+  }
 
   if (!options.projectName) {
     questions.push({
       type: 'input',
       name: 'projectName',
       message: 'Nom du projet :',
+      default: (answers: inquirer.Answers) => {
+        const targetDirectory = (options.targetDirectory ?? answers.targetDirectory ?? '').toString();
+        if (!targetDirectory) {
+          return 'mon-api';
+        }
+        const resolved = path.resolve(targetDirectory.trim());
+        return path.basename(resolved);
+      },
       validate: (input: string) => (input.trim().length > 0 ? true : 'Le nom du projet est obligatoire.'),
     });
   }
@@ -75,13 +111,30 @@ export async function promptForMissingOptions(options: PromptOptions): Promise<P
     });
   }
 
+  if (!options.dataProviders) {
+    questions.push({
+      type: 'checkbox',
+      name: 'dataProviders',
+      message: 'Préparez-vous une base de données ou un stockage objet ? (plusieurs choix possibles)',
+      choices: dataProviderCatalog.map((provider) => ({
+        name: `${provider.name} — ${provider.description}`,
+        value: provider.key,
+      })),
+      default: [],
+    });
+  }
+
   const answers = await inquirer.prompt(questions);
 
+  const targetDirectory = options.targetDirectory ?? answers.targetDirectory ?? options.projectName ?? answers.projectName;
   const projectName = options.projectName ?? answers.projectName;
   const language = options.language ?? answers.language;
   const rawFeatures: FeatureKey[] = options.features ?? answers.features;
   const resolvedFeatures = resolveFeatureDependencies(rawFeatures);
   const packageManager = options.packageManager ?? answers.packageManager;
+  const dataProviders: DataProviderKey[] = Array.from(
+    new Set((options.dataProviders ?? answers.dataProviders ?? []) as DataProviderKey[])
+  );
 
   const missingDependencies = resolvedFeatures.filter((featureKey) =>
     featureCatalogMap.get(featureKey)?.dependencies?.some((dependency) => !resolvedFeatures.includes(dependency))
@@ -91,10 +144,17 @@ export async function promptForMissingOptions(options: PromptOptions): Promise<P
     throw new Error(`Impossible de résoudre les dépendances des modules : ${missingDependencies.join(', ')}`);
   }
 
+  const unknownProviders = dataProviders.filter((provider) => !dataProviderCatalogMap.has(provider));
+  if (unknownProviders.length > 0) {
+    throw new Error(`Options de persistance inconnues : ${unknownProviders.join(', ')}`);
+  }
+
   return {
+    targetDirectory,
     projectName,
     language,
     features: resolvedFeatures,
     packageManager,
+    dataProviders,
   };
 }

--- a/templates/javascript/base/.env.example.ejs
+++ b/templates/javascript/base/.env.example.ejs
@@ -10,3 +10,23 @@ JWT_REFRESH_SECRET=change-me-refresh
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=7d
 <% } %>
+<% if (dataProviders.includes('postgresql')) { %>
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app
+# DATABASE_URL doit pointer vers votre instance PostgreSQL (format libpq).
+<% } %>
+<% if (dataProviders.includes('mysql')) { %>
+MYSQL_DSN=mysql://root:root@localhost:3306/app
+# Fournissez un DSN complet (mysql://user:pass@host:port/database).
+<% } %>
+<% if (dataProviders.includes('sqlite')) { %>
+SQLITE_DATABASE_PATH=./var/sqlite/app.db
+# Le fichier est créé automatiquement si absent.
+<% } %>
+<% if (dataProviders.includes('s3')) { %>
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+S3_BUCKET_NAME=
+S3_ENDPOINT=
+# Renseignez les identifiants S3 (ou MinIO) pour activer les diagnostics de stockage.
+<% } %>

--- a/templates/javascript/base/README.md.ejs
+++ b/templates/javascript/base/README.md.ejs
@@ -12,6 +12,17 @@ Généré avec **create-template-api** le <%- createdAt %>.
 <% }); %>
 <% } %>
 
+<% if (dataProviderSummaries.length) { %>
+## 🗄️ Persistance & stockage préparés
+
+<% dataProviderSummaries.forEach((summary) => { %>- <%- summary %>
+<% }); %>
+<% } else { %>
+## 🗄️ Persistance & stockage
+
+- Aucun connecteur de persistance sélectionné. Branchez vos adapters dans `src/infrastructure`.
+<% } %>
+
 ## 🗂 Architecture hexagonale
 
 ```
@@ -28,6 +39,17 @@ src/
 <%- packageManagerCommands.install %>
 <%- packageManagerCommands.run %> dev
 ```
+
+<% const apiStatusCommand = packageManager === 'npm' ? 'npm run api -- --status' : packageManager === 'pnpm' ? 'pnpm api --status' : 'yarn api --status'; %>
+
+### Diagnostic assisté
+
+```bash
+<%- apiStatusCommand %>
+```
+
+Vérifie automatiquement `/health` et `/status` en mettant en évidence les modules et options de persistance sélectionnés et
+affiche un résumé clair des diagnostics collectés.
 
 ### Scripts utiles
 
@@ -46,6 +68,9 @@ src/
 ```bash
 <%- packageManagerCommands.run %> test
 ```
+
+Des scénarios d'intégration couvrent l'authentification, la gestion des utilisateurs (CRUD complet) et les portails optionnels
+pour garantir le bon fonctionnement du template dès la génération.
 
 ## 🛡 Bonnes pratiques
 

--- a/templates/typescript/base/.env.example.ejs
+++ b/templates/typescript/base/.env.example.ejs
@@ -10,3 +10,23 @@ JWT_REFRESH_SECRET=change-me-refresh
 ACCESS_TOKEN_TTL=15m
 REFRESH_TOKEN_TTL=7d
 <% } %>
+<% if (dataProviders.includes('postgresql')) { %>
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app
+# DATABASE_URL doit pointer vers votre instance PostgreSQL (format standard libpq).
+<% } %>
+<% if (dataProviders.includes('mysql')) { %>
+MYSQL_DSN=mysql://root:root@localhost:3306/app
+# Utilisez un DSN MySQL complet (mysql://user:pass@host:port/database).
+<% } %>
+<% if (dataProviders.includes('sqlite')) { %>
+SQLITE_DATABASE_PATH=./var/sqlite/app.db
+# Le fichier est créé automatiquement si besoin.
+<% } %>
+<% if (dataProviders.includes('s3')) { %>
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+S3_BUCKET_NAME=
+# Si vous utilisez un endpoint compatible S3 (MinIO, etc.), ajoutez S3_ENDPOINT.
+S3_ENDPOINT=
+<% } %>

--- a/templates/typescript/base/README.md.ejs
+++ b/templates/typescript/base/README.md.ejs
@@ -13,6 +13,17 @@ Généré avec **create-template-api** le <%- createdAt %>.
 <% }); %>
 <% } %>
 
+<% if (dataProviderSummaries.length) { %>
+## 🗄️ Persistance & stockage préparés
+
+<% dataProviderSummaries.forEach((summary) => { %>- <%- summary %>
+<% }); %>
+<% } else { %>
+## 🗄️ Persistance & stockage
+
+- Aucune intégration de base de données ou de stockage n'a été sélectionnée. Branchez vos adapters dans `src/infrastructure`.
+<% } %>
+
 ## 🗂 Architecture hexagonale
 
 ```
@@ -40,6 +51,18 @@ curl http://localhost:3333/status
 
 Vous obtenez un instantané JSON avec l'état global, les fonctionnalités activées, les dépendances simulées
 et les liens utiles. Pour un simple ping, `GET /health` reste disponible.
+
+<% const apiStatusCommand = packageManager === 'npm' ? 'npm run api -- --status' : packageManager === 'pnpm' ? 'pnpm api --status' : 'yarn api --status'; %>
+
+### Diagnostic assisté en CLI
+
+```bash
+<%- apiStatusCommand %>
+```
+
+Ce script lance automatiquement `GET /health` et `GET /status`, vérifie les fonctionnalités choisies ainsi que les options
+de persistance déclarées et vous alerte si une dépendance critique est en erreur. Un résumé lisible présente les modules
+actifs, l'état des stockages configurés et les diagnostics agrégés.
 <% if (features.includes('auth')) { %>
 
 ### Scénario d'authentification prêt à l'emploi
@@ -89,6 +112,8 @@ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" http://localhost:3333/me
 ```
 
 Les tests reposent sur Jest et Supertest. Des doubles in-memory permettent d'isoler les cas d'usage des dépendances.
+Chaque fonctionnalité activée dispose de scénarios de bout en bout : flux d'authentification, gestion complète des
+utilisateurs (création, consultation, mise à jour, suppression) et espaces client / admin lorsqu'ils sont sélectionnés.
 
 ## 🛡 Sécurité & bonnes pratiques
 

--- a/templates/typescript/base/scripts/api-cli.ts.ejs
+++ b/templates/typescript/base/scripts/api-cli.ts.ejs
@@ -1,0 +1,215 @@
+#!/usr/bin/env ts-node
+import process from 'node:process';
+import request from 'supertest';
+import { createApp } from '../src/interface/http/app';
+import { templateInfo } from '../src/infrastructure/config/template-info';
+
+interface ApiSnapshot {
+  status?: string;
+  features: Array<{ key?: string; name?: string; summary?: string }>;
+  dependencies: Array<{ name?: string; status?: string; details?: string }>;
+  dataProviders: Array<{ key?: string; name?: string; status?: string; details?: string }>;
+}
+
+type CheckResult = {
+  errors: string[];
+  warnings: string[];
+  snapshot: ApiSnapshot;
+};
+
+async function ensureContainerIsReady() {
+  const hasAuthFeature = templateInfo.features.some((feature) => feature.key === 'auth');
+  if (!hasAuthFeature) {
+    return;
+  }
+
+  try {
+    const containerModule: Record<string, unknown> = await import('../src/infrastructure/container');
+    const maybeReady = containerModule.containerReady;
+    if (maybeReady && typeof maybeReady === 'object' && 'then' in maybeReady) {
+      await maybeReady;
+    }
+  } catch (error) {
+    console.warn(
+      `⚠️  Impossible d'attendre le container d'injection : ${(error as Error).message}.` +
+        " Les vérifications se poursuivent tout de même."
+    );
+  }
+}
+
+async function runStatusAudit(): Promise<CheckResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  await ensureContainerIsReady();
+
+  const app = createApp();
+
+  const healthResponse = await request(app).get('/health');
+  if (healthResponse.status !== 200) {
+    errors.push(`GET /health a renvoyé le statut HTTP ${healthResponse.status}.`);
+  }
+
+  const statusResponse = await request(app).get('/status');
+  if (statusResponse.status !== 200) {
+    errors.push(`GET /status a renvoyé le statut HTTP ${statusResponse.status}.`);
+    return {
+      errors,
+      warnings,
+      snapshot: { status: undefined, features: [], dependencies: [], dataProviders: [] },
+    };
+  }
+
+  const payload = statusResponse.body ?? {};
+  const snapshot: ApiSnapshot = {
+    status: payload.status,
+    features: Array.isArray(payload.features) ? payload.features : [],
+    dependencies: Array.isArray(payload.dependencies) ? payload.dependencies : [],
+    dataProviders: Array.isArray(payload.dataProviders) ? payload.dataProviders : [],
+  };
+
+  if (snapshot.status && snapshot.status !== 'ok') {
+    warnings.push(`Statut global renvoyé: "${snapshot.status}".`);
+  }
+
+  const featureKeys = new Set<string>((snapshot.features ?? []).map((feature) => feature?.key ?? ''));
+  for (const feature of templateInfo.features) {
+    if (!featureKeys.has(feature.key)) {
+      errors.push(`La fonctionnalité "${feature.name}" (${feature.key}) est absente de /status.`);
+    }
+  }
+
+  const dependencyStatuses = new Map<string, { name?: string; status?: string; details?: string }>(
+    snapshot.dependencies.map((dependency) => [dependency?.name ?? 'unknown', dependency ?? {}])
+  );
+
+  for (const dependency of dependencyStatuses.values()) {
+    if (dependency.status === 'critical') {
+      errors.push(
+        `La dépendance "${dependency.name}" est en statut critique (${dependency.details ?? 'aucun détail fourni'}).`
+      );
+    } else if (dependency.status === 'warning') {
+      warnings.push(
+        `La dépendance "${dependency.name}" nécessite une attention particulière (${dependency.details ?? 'aucun détail fourni'}).`
+      );
+    }
+  }
+
+  const providerStatuses = new Map<string, { key?: string; status?: string; details?: string }>(
+    snapshot.dataProviders.map((provider) => [provider?.key ?? 'unknown', provider ?? {}])
+  );
+
+  for (const provider of templateInfo.dataProviders) {
+    const status = providerStatuses.get(provider.key);
+    if (!status) {
+      warnings.push(`L'option de persistance "${provider.name}" n'apparaît pas encore dans /status.`);
+      continue;
+    }
+    if (status.status === 'critical') {
+      errors.push(`"${provider.name}" est en échec critique (${status.details ?? 'aucun détail fourni'}).`);
+    } else if (status.status === 'warning') {
+      warnings.push(
+        `"${provider.name}" nécessite une configuration supplémentaire (${status.details ?? provider.details}).`
+      );
+    }
+  }
+
+  return { errors, warnings, snapshot };
+}
+
+function formatItemLine(label: string, status?: string, details?: string) {
+  const statusLabel = status ? status.toUpperCase() : 'INCONNU';
+  const segments = [`${label} [${statusLabel}]`];
+  if (details) {
+    segments.push(details);
+  }
+  return segments.join(' — ');
+}
+
+function printSummary(snapshot: ApiSnapshot) {
+  console.log('');
+  console.log(`Résumé API : ${snapshot.status ? snapshot.status.toUpperCase() : 'INCONNU'}`);
+
+  if (snapshot.features.length > 0) {
+    console.log(`Fonctionnalités (${snapshot.features.length}) :`);
+    for (const feature of snapshot.features) {
+      const label = feature.name ?? feature.key ?? 'Inconnue';
+      const summary = feature.summary ? ` — ${feature.summary}` : '';
+      console.log(`  - ${label}${summary}`);
+    }
+  } else {
+    console.log("Fonctionnalités : aucune fonctionnalité détectée dans /status.");
+  }
+
+  if (snapshot.dataProviders.length > 0) {
+    console.log('Persistance :');
+    for (const provider of snapshot.dataProviders) {
+      const label = provider.name ?? provider.key ?? 'Inconnue';
+      console.log(`  - ${formatItemLine(label, provider.status, provider.details)}`);
+    }
+  } else {
+    console.log('Persistance : aucune option sélectionnée.');
+  }
+
+  if (snapshot.dependencies.length > 0) {
+    console.log('Dépendances :');
+    for (const dependency of snapshot.dependencies) {
+      const label = dependency.name ?? 'Inconnue';
+      console.log(`  - ${formatItemLine(label, dependency.status, dependency.details)}`);
+    }
+  }
+
+  console.log('');
+}
+
+function printHelp() {
+  const command = process.argv[1]?.includes('node_modules') ? 'npm run api -- --status' : 'api --status';
+  console.log('Usage :');
+  console.log(`  ${command}`);
+  console.log('');
+  console.log('Options :');
+  console.log('  --status       Lance un audit rapide de /health et /status (par défaut).');
+  console.log('  -h, --help     Affiche cette aide.');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  const wantsStatus = args.length === 0 || args.includes('--status') || args.includes('status');
+  if (!wantsStatus) {
+    console.error(`Commande inconnue: ${args.join(' ') || '(aucune)'}.`);
+    printHelp();
+    process.exit(1);
+  }
+
+  console.log('🔍 Vérification du statut API...');
+
+  try {
+    const { errors, warnings, snapshot } = await runStatusAudit();
+
+    for (const warning of warnings) {
+      console.warn(`⚠️  ${warning}`);
+    }
+
+    printSummary(snapshot);
+
+    if (errors.length > 0) {
+      for (const error of errors) {
+        console.error(`❌ ${error}`);
+      }
+      process.exit(1);
+    }
+
+    console.log('✅ API opérationnelle : /health et /status répondent correctement.');
+  } catch (error) {
+    console.error(`❌ Audit impossible : ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/templates/typescript/base/src/application/use-cases/status/get-api-status.usecase.ts.ejs
+++ b/templates/typescript/base/src/application/use-cases/status/get-api-status.usecase.ts.ejs
@@ -27,6 +27,14 @@ export interface ApiStatusResponse {
     status: 'ok' | 'warning' | 'critical' | 'skipped';
     details?: string;
   }>;
+  dataProviders: Array<{
+    key: string;
+    name: string;
+    summary: string;
+    kind: 'database' | 'orm' | 'storage';
+    status: 'ok' | 'warning' | 'critical' | 'skipped';
+    details: string;
+  }>;
 }
 
 export class GetApiStatusUseCase {
@@ -58,6 +66,7 @@ export class GetApiStatusUseCase {
         description: feature.description,
       })),
       dependencies: snapshot.dependencies.map((dependency) => ({ ...dependency })),
+      dataProviders: snapshot.dataProviders.map((provider) => ({ ...provider })),
     };
   }
 }

--- a/templates/typescript/base/src/domain/status/system-info.ts.ejs
+++ b/templates/typescript/base/src/domain/status/system-info.ts.ejs
@@ -13,6 +13,15 @@ export interface FeatureDescriptor {
   summary: string;
 }
 
+export interface DataProviderDescriptor {
+  key: string;
+  name: string;
+  summary: string;
+  kind: 'database' | 'orm' | 'storage';
+  status: DependencyHealth;
+  details: string;
+}
+
 export interface SystemInfoSnapshot {
   name: string;
   version: string;
@@ -21,6 +30,7 @@ export interface SystemInfoSnapshot {
   documentationUrl: string;
   features: FeatureDescriptor[];
   dependencies: DependencyStatus[];
+  dataProviders: DataProviderDescriptor[];
 }
 
 export interface SystemInfoProvider {

--- a/templates/typescript/base/src/infrastructure/config/env.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/config/env.ts.ejs
@@ -14,6 +14,22 @@ const envSchema = z.object({
   ACCESS_TOKEN_TTL: z.string().default('15m'),
   REFRESH_TOKEN_TTL: z.string().default('7d'),
 <% } %>
+<% if (dataProviders.includes('postgresql')) { %>
+  DATABASE_URL: z.string().optional(),
+<% } %>
+<% if (dataProviders.includes('mysql')) { %>
+  MYSQL_DSN: z.string().optional(),
+<% } %>
+<% if (dataProviders.includes('sqlite')) { %>
+  SQLITE_DATABASE_PATH: z.string().optional(),
+<% } %>
+<% if (dataProviders.includes('s3')) { %>
+  AWS_REGION: z.string().optional(),
+  AWS_ACCESS_KEY_ID: z.string().optional(),
+  AWS_SECRET_ACCESS_KEY: z.string().optional(),
+  S3_BUCKET_NAME: z.string().optional(),
+  S3_ENDPOINT: z.string().optional(),
+<% } %>
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/templates/typescript/base/src/infrastructure/config/template-info.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/config/template-info.ts.ejs
@@ -1,4 +1,4 @@
-import { DependencyStatus, FeatureDescriptor } from '../../domain/status/system-info';
+import { DataProviderDescriptor, DependencyStatus, FeatureDescriptor } from '../../domain/status/system-info';
 
 const features: FeatureDescriptor[] = <%- JSON.stringify(
   selectedFeatures.map((feature) => ({
@@ -6,6 +6,19 @@ const features: FeatureDescriptor[] = <%- JSON.stringify(
     name: feature.name,
     description: feature.description,
     summary: feature.summary,
+  })),
+  null,
+  2
+) %>;
+
+const dataProviders: DataProviderDescriptor[] = <%- JSON.stringify(
+  selectedDataProviders.map((provider) => ({
+    key: provider.key,
+    name: provider.name,
+    summary: provider.summary,
+    kind: provider.kind,
+    status: provider.defaultStatus,
+    details: provider.statusDescription,
   })),
   null,
   2
@@ -24,8 +37,12 @@ const dependencies: DependencyStatus[] = [
   },
   {
     name: 'database',
-    status: 'skipped',
-    details: "Aucune base de données n'est configurée par défaut. Ajoutez vos adapters lorsque vous en aurez besoin.",
+    status: <%- selectedDataProviders.length > 0 ? `'warning'` : `'skipped'` %>,
+    details: <%- JSON.stringify(
+      selectedDataProviders.length > 0
+        ? 'Clients installés. Configurez vos adapters pour activer la connexion.'
+        : "Aucune base de données n'est configurée par défaut. Ajoutez vos adapters lorsque vous en aurez besoin."
+    ) %>,
   },
 ];
 
@@ -58,11 +75,21 @@ dependencies.push({
 });
 <% } %>
 
+<% selectedDataProviders.forEach((provider) => { %>
+dependencies.push(<%- JSON.stringify({
+  name: provider.name,
+  status: provider.defaultStatus,
+  details: provider.statusDescription,
+}) %>);
+<% }); %>
+
 export const templateInfo = {
   projectName: '<%- projectName %>',
   features,
+  dataProviders,
   dependencies,
 } as const;
 
 export type GeneratedFeatureDescriptor = (typeof templateInfo.features)[number];
 export type GeneratedDependencyStatus = (typeof templateInfo.dependencies)[number];
+export type GeneratedDataProviderDescriptor = (typeof templateInfo.dataProviders)[number];

--- a/templates/typescript/base/src/infrastructure/status/config-system-info.provider.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/status/config-system-info.provider.ts.ejs
@@ -2,9 +2,38 @@ import packageJson from '../../../package.json';
 import { SystemInfoProvider, SystemInfoSnapshot } from '../../domain/status/system-info';
 import { env } from '../config/env';
 import { templateInfo } from '../config/template-info';
+import { evaluateDataProviders } from './data-provider-health';
 
 export class ConfigSystemInfoProvider implements SystemInfoProvider {
   async getSnapshot(): Promise<SystemInfoSnapshot> {
+    const dataProviders = await evaluateDataProviders(templateInfo.dataProviders);
+
+    const dependencies = templateInfo.dependencies.map((dependency) => {
+      if (dependency.name === 'database') {
+        if (dataProviders.length === 0) {
+          return { ...dependency, status: 'skipped', details: dependency.details };
+        }
+
+        const hasCritical = dataProviders.some((provider) => provider.status === 'critical');
+        const hasWarning = dataProviders.some((provider) => provider.status === 'warning');
+
+        return {
+          ...dependency,
+          status: hasCritical ? 'critical' : hasWarning ? 'warning' : 'ok',
+          details: dataProviders
+            .map((provider) => `${provider.name}: ${provider.details}`)
+            .join(' '),
+        };
+      }
+
+      const provider = dataProviders.find((item) => item.name === dependency.name);
+      if (provider) {
+        return { ...dependency, status: provider.status, details: provider.details };
+      }
+
+      return { ...dependency };
+    });
+
     return {
       name: env.APP_NAME,
       version: packageJson.version ?? '0.0.0',
@@ -12,7 +41,8 @@ export class ConfigSystemInfoProvider implements SystemInfoProvider {
       port: env.API_PORT,
       documentationUrl: '/docs',
       features: templateInfo.features.map((feature) => ({ ...feature })),
-      dependencies: templateInfo.dependencies.map((dependency) => ({ ...dependency })),
+      dependencies,
+      dataProviders,
     };
   }
 }

--- a/templates/typescript/base/src/infrastructure/status/data-provider-health.ts.ejs
+++ b/templates/typescript/base/src/infrastructure/status/data-provider-health.ts.ejs
@@ -1,0 +1,242 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import type { DataProviderDescriptor } from '../../domain/status/system-info';
+
+const DIAGNOSTIC_TIMEOUT = 2500;
+
+type Evaluator = (descriptor: DataProviderDescriptor) => Promise<DataProviderDescriptor>;
+
+function formatMissingEnvMessage(keys: string[]): string {
+  return keys.length === 1
+    ? `Variable d'environnement manquante : ${keys[0]}.`
+    : `Variables d'environnement manquantes : ${keys.join(', ')}.`;
+}
+
+function sanitizeString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+const evaluators: Record<string, Evaluator> = {
+<% if (dataProviders.includes('postgresql')) { %>
+  async postgresql(descriptor) {
+    const connectionString = sanitizeString(process.env.DATABASE_URL);
+
+    if (!connectionString) {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: "Définissez DATABASE_URL pour activer la connexion PostgreSQL.",
+      };
+    }
+
+    const { Client } = await import('pg');
+    const client = new Client({ connectionString, connectionTimeoutMillis: DIAGNOSTIC_TIMEOUT });
+
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      return {
+        ...descriptor,
+        status: 'ok',
+        details: 'Connexion PostgreSQL opérationnelle.',
+      };
+    } catch (error) {
+      return {
+        ...descriptor,
+        status: 'critical',
+        details: `Connexion PostgreSQL impossible : ${(error as Error).message}`,
+      };
+    } finally {
+      await client.end().catch(() => undefined);
+    }
+  },
+<% } %>
+<% if (dataProviders.includes('mysql')) { %>
+  async mysql(descriptor) {
+    const dsn = sanitizeString(process.env.MYSQL_DSN);
+
+    if (!dsn) {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: 'Définissez MYSQL_DSN pour activer la connexion MySQL.',
+      };
+    }
+
+    try {
+      const mysql = await import('mysql2/promise');
+      const url = new URL(dsn);
+      const connection = await mysql.createConnection({
+        host: url.hostname,
+        port: Number(url.port || '3306'),
+        user: decodeURIComponent(url.username || ''),
+        password: url.password ? decodeURIComponent(url.password) : undefined,
+        database: url.pathname.replace(/^\//, '') || undefined,
+        connectTimeout: DIAGNOSTIC_TIMEOUT,
+      });
+
+      try {
+        await connection.ping();
+        return {
+          ...descriptor,
+          status: 'ok',
+          details: 'Connexion MySQL opérationnelle.',
+        };
+      } finally {
+        await connection.end().catch(() => undefined);
+      }
+    } catch (error) {
+      return {
+        ...descriptor,
+        status: 'critical',
+        details: `Connexion MySQL impossible : ${(error as Error).message}`,
+      };
+    }
+  },
+<% } %>
+<% if (dataProviders.includes('sqlite')) { %>
+  async sqlite(descriptor) {
+    const databasePath = sanitizeString(process.env.SQLITE_DATABASE_PATH);
+
+    if (!databasePath) {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: 'Définissez SQLITE_DATABASE_PATH pour activer SQLite.',
+      };
+    }
+
+    const resolvedPath = path.resolve(process.cwd(), databasePath);
+    const directory = path.dirname(resolvedPath);
+
+    await fs.mkdir(directory, { recursive: true });
+
+    try {
+      const sqliteModule = await import('better-sqlite3');
+      const Database = sqliteModule.default;
+      const db = new Database(resolvedPath, { timeout: DIAGNOSTIC_TIMEOUT });
+      db.pragma('journal_mode = WAL');
+      db.close();
+
+      return {
+        ...descriptor,
+        status: 'ok',
+        details: `Base SQLite prête (${resolvedPath}).`,
+      };
+    } catch (error) {
+      return {
+        ...descriptor,
+        status: 'critical',
+        details: `SQLite indisponible : ${(error as Error).message}`,
+      };
+    }
+  },
+<% } %>
+<% if (dataProviders.includes('prisma')) { %>
+  async prisma(descriptor) {
+    const schemaPath = path.resolve(process.cwd(), 'prisma/schema.prisma');
+
+    try {
+      await fs.access(schemaPath);
+      return {
+        ...descriptor,
+        status: 'ok',
+        details: 'Schéma Prisma détecté. Exécutez `prisma generate` pour générer le client.',
+      };
+    } catch {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: 'Initialisez Prisma avec `npx prisma init` pour créer prisma/schema.prisma.',
+      };
+    }
+  },
+<% } %>
+<% if (dataProviders.includes('s3')) { %>
+  async s3(descriptor) {
+    const region = sanitizeString(process.env.AWS_REGION);
+    const accessKeyId = sanitizeString(process.env.AWS_ACCESS_KEY_ID);
+    const secretAccessKey = sanitizeString(process.env.AWS_SECRET_ACCESS_KEY);
+    const bucket = sanitizeString(process.env.S3_BUCKET_NAME);
+
+    const missingEnv = [
+      ['AWS_REGION', region],
+      ['AWS_ACCESS_KEY_ID', accessKeyId],
+      ['AWS_SECRET_ACCESS_KEY', secretAccessKey],
+      ['S3_BUCKET_NAME', bucket],
+    ]
+      .filter(([, value]) => !value)
+      .map(([key]) => key);
+
+    if (missingEnv.length > 0) {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: `${formatMissingEnvMessage(missingEnv)}`,
+      };
+    }
+
+    try {
+      const { S3Client } = await import('@aws-sdk/client-s3');
+      const client = new S3Client({
+        region: region!,
+        credentials: {
+          accessKeyId: accessKeyId!,
+          secretAccessKey: secretAccessKey!,
+        },
+        endpoint: sanitizeString(process.env.S3_ENDPOINT),
+      });
+
+      const credentials = client.config.credentials;
+      if (typeof credentials === 'function') {
+        await credentials();
+      }
+
+      client.destroy();
+
+      return {
+        ...descriptor,
+        status: 'ok',
+        details: `Configuration S3 détectée pour le bucket ${bucket}.`,
+      };
+    } catch (error) {
+      return {
+        ...descriptor,
+        status: 'warning',
+        details: `Client S3 non initialisé : ${(error as Error).message}`,
+      };
+    }
+  },
+<% } %>
+};
+
+export async function evaluateDataProviders(
+  descriptors: DataProviderDescriptor[]
+): Promise<DataProviderDescriptor[]> {
+  if (descriptors.length === 0) {
+    return [];
+  }
+
+  return Promise.all(
+    descriptors.map(async (descriptor) => {
+      const evaluator = evaluators[descriptor.key];
+      if (!evaluator) {
+        return descriptor;
+      }
+
+      try {
+        return await evaluator({ ...descriptor });
+      } catch (error) {
+        return {
+          ...descriptor,
+          status: 'warning',
+          details: `Diagnostic impossible : ${(error as Error).message}`,
+        };
+      }
+    })
+  );
+}

--- a/templates/typescript/base/src/interface/http/docs/openapi.ts.ejs
+++ b/templates/typescript/base/src/interface/http/docs/openapi.ts.ejs
@@ -422,6 +422,21 @@ export const openApiDocument: OpenAPIV3.Document = {
             type: 'array',
             items: { $ref: '#/components/schemas/DependencyStatus' },
           },
+          dataProviders: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/DataProvider' },
+          },
+        },
+      },
+      DataProvider: {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          name: { type: 'string' },
+          summary: { type: 'string' },
+          kind: { type: 'string', enum: ['database', 'orm', 'storage'] },
+          status: { type: 'string', enum: ['ok', 'warning', 'critical', 'skipped'] },
+          details: { type: 'string' },
         },
       },
       HealthResponse: {

--- a/templates/typescript/base/tests/integration/authentication.spec.ts.ejs
+++ b/templates/typescript/base/tests/integration/authentication.spec.ts.ejs
@@ -42,5 +42,27 @@ describe('Authentication flows', () => {
       expect.objectContaining({ accessToken: expect.any(String), refreshToken: expect.any(String) })
     );
   });
+
+  it('revokes refresh tokens after logout', async () => {
+    const app = await buildTestApp();
+
+    const loginResponse = await request(app).post('/auth/login').send({
+      email: 'admin@example.com',
+      password: 'Admin#1234',
+    });
+
+    const { accessToken, refreshToken } = loginResponse.body.tokens;
+
+    const logoutResponse = await request(app).post('/auth/logout').set('Authorization', `Bearer ${accessToken}`).send({
+      refreshToken,
+    });
+
+    expect(logoutResponse.status).toBe(204);
+
+    const refreshResponse = await request(app).post('/auth/refresh').send({ refreshToken });
+
+    expect(refreshResponse.status).toBe(401);
+    expect(refreshResponse.body).toMatchObject({ error: 'AuthenticationError' });
+  });
 });
 <% } %>

--- a/templates/typescript/base/tests/integration/status.spec.ts.ejs
+++ b/templates/typescript/base/tests/integration/status.spec.ts.ejs
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import { buildTestApp } from '../utils/test-app';
+import { templateInfo } from '../../src/infrastructure/config/template-info';
 
 describe('API status', () => {
   it('returns a comprehensive API snapshot', async () => {
@@ -9,7 +10,7 @@ describe('API status', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
-      status: 'ok',
+      status: expect.stringMatching(/^(ok|degraded)$/),
       info: {
         name: expect.any(String),
         version: expect.any(String),
@@ -22,7 +23,40 @@ describe('API status', () => {
       },
     });
 
-    expect(Array.isArray(response.body.features)).toBe(true);
-    expect(Array.isArray(response.body.dependencies)).toBe(true);
+    const features: Array<{ key: string }> = response.body.features ?? [];
+    const dependencies: Array<{ name: string; status?: string }> = response.body.dependencies ?? [];
+    const dataProviders: Array<{ key: string; status?: string; details?: string }> = response.body.dataProviders ?? [];
+
+    const featureKeys = new Set(features.map((feature) => feature.key));
+    for (const feature of templateInfo.features) {
+      expect(featureKeys.has(feature.key)).toBe(true);
+    }
+
+    const dependencyMap = new Map(dependencies.map((dependency) => [dependency.name, dependency]));
+    expect(dependencyMap.has('http')).toBe(true);
+    expect(dependencyMap.has('documentation')).toBe(true);
+
+    const databaseDependency = dependencyMap.get('database');
+
+    if (templateInfo.dataProviders.length === 0) {
+      expect(dataProviders).toEqual([]);
+      if (databaseDependency) {
+        expect(databaseDependency.status).toBe('skipped');
+      }
+    } else {
+      const providerMap = new Map(dataProviders.map((provider) => [provider.key, provider]));
+
+      for (const provider of templateInfo.dataProviders) {
+        const snapshot = providerMap.get(provider.key);
+        expect(snapshot).toBeDefined();
+        expect(snapshot).toMatchObject({
+          status: expect.stringMatching(/^(ok|warning|critical|skipped)$/),
+          details: expect.any(String),
+        });
+      }
+
+      expect(databaseDependency).toBeDefined();
+      expect(databaseDependency?.status).toMatch(/^(ok|warning|critical)$/);
+    }
   });
 });

--- a/templates/typescript/features/userCrud/tests/integration/users.spec.ts.ejs
+++ b/templates/typescript/features/userCrud/tests/integration/users.spec.ts.ejs
@@ -12,20 +12,38 @@ describe('User administration', () => {
     return { app, token: response.body.tokens.accessToken };
   }
 
+  async function createUser(
+    app: Awaited<ReturnType<typeof buildTestApp>>,
+    token: string,
+    overrides: Partial<{ name: string; email: string; password: string; role: string }> = {}
+  ) {
+    const payload = {
+      name: 'New Client',
+      email: 'new-client@example.com',
+      password: 'Client#1234',
+      role: 'client',
+      ...overrides,
+    };
+
+    const response = await request(app)
+      .post('/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send(payload);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      id: expect.any(String),
+      email: payload.email,
+      role: payload.role,
+    });
+
+    return response.body;
+  }
+
   it('allows an admin to list and create users', async () => {
     const { app, token } = await authenticateAdmin();
 
-    const createResponse = await request(app)
-      .post('/users')
-      .set('Authorization', `Bearer ${token}`)
-      .send({
-        name: 'New Client',
-        email: 'new-client@example.com',
-        password: 'Client#1234',
-        role: 'client',
-      });
-
-    expect(createResponse.status).toBe(201);
+    const created = await createUser(app, token);
 
     const listResponse = await request(app)
       .get('/users')
@@ -33,5 +51,45 @@ describe('User administration', () => {
 
     expect(listResponse.status).toBe(200);
     expect(Array.isArray(listResponse.body.users)).toBe(true);
+    expect(listResponse.body.users.some((user: { id: string }) => user.id === created.id)).toBe(true);
+  });
+
+  it('allows an admin to view, update and delete a user', async () => {
+    const { app, token } = await authenticateAdmin();
+
+    const created = await createUser(app, token, {
+      name: 'Client Demo',
+      email: 'client-demo@example.com',
+    });
+
+    const showResponse = await request(app)
+      .get(`/users/${created.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(showResponse.status).toBe(200);
+    expect(showResponse.body).toMatchObject({ id: created.id, email: 'client-demo@example.com' });
+
+    const updateResponse = await request(app)
+      .patch(`/users/${created.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated Client',
+        role: 'client',
+      });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body).toMatchObject({ id: created.id, name: 'Updated Client' });
+
+    const deleteResponse = await request(app)
+      .delete(`/users/${created.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(deleteResponse.status).toBe(204);
+
+    const afterDeleteResponse = await request(app)
+      .get(`/users/${created.id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(afterDeleteResponse.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- add runtime data-provider diagnostics, enrich `/status`, and improve the `npm run api -- --status` summary output
- extend configuration scaffolding and README/.env guidance for database and storage options
- broaden generated integration tests to cover logout, full user CRUD, and persistence reporting